### PR TITLE
Rename locale checker to follow IEFT standard

### DIFF
--- a/lib/i18n/hygiene/variable_checker.rb
+++ b/lib/i18n/hygiene/variable_checker.rb
@@ -5,7 +5,7 @@ module I18n
     # in any other locale must have a matching variable name.
     class VariableChecker
 
-      NON_ENGLISH_LOCALES_TO_CHECK = [ :fr_fr ]
+      NON_ENGLISH_LOCALES_TO_CHECK = [ :fr ]
 
       def initialize(key, i18n_wrapper)
         @key = key

--- a/spec/lib/i18n/hygiene/keys_with_entities_spec.rb
+++ b/spec/lib/i18n/hygiene/keys_with_entities_spec.rb
@@ -4,7 +4,7 @@ require 'i18n/hygiene'
 describe I18n::Hygiene::KeysWithEntities do
   describe "#to_a" do
     context "when one key that shouldn't contains an HTML entity" do
-      let(:locales) { [:en, :fr_fr] }
+      let(:locales) { [:en, :fr] }
       let(:keys_to_check) { %w[foo bar foo_html foo_markdown] }
       let(:i18nwrapper) { instance_double(I18n::Hygiene::Wrapper, locales: locales, keys_to_check: keys_to_check) }
       let(:collection) { I18n::Hygiene::KeysWithEntities.new(i18nwrapper: i18nwrapper) }
@@ -14,14 +14,14 @@ describe I18n::Hygiene::KeysWithEntities do
         allow(i18nwrapper).to receive(:value).with(:en, "bar") { "one&nbsp;two" }
         allow(i18nwrapper).to receive(:value).with(:en, "foo_html") { "one&nbsp;two" }
         allow(i18nwrapper).to receive(:value).with(:en, "foo_markdown") { "one&nbsp;two" }
-        allow(i18nwrapper).to receive(:value).with(:fr_fr, "foo") { "one&ngsp;two" }
-        allow(i18nwrapper).to receive(:value).with(:fr_fr, "foo_html") { "one&ngsp;two" }
-        allow(i18nwrapper).to receive(:value).with(:fr_fr, "foo_markdown") { "one&ngsp;two" }
-        allow(i18nwrapper).to receive(:value).with(:fr_fr, "bar") { "one two" }
+        allow(i18nwrapper).to receive(:value).with(:fr, "foo") { "one&ngsp;two" }
+        allow(i18nwrapper).to receive(:value).with(:fr, "foo_html") { "one&ngsp;two" }
+        allow(i18nwrapper).to receive(:value).with(:fr, "foo_markdown") { "one&ngsp;two" }
+        allow(i18nwrapper).to receive(:value).with(:fr, "bar") { "one two" }
       end
 
       it "returns the appropriate result" do
-        expect(collection.to_a).to eq ["en: bar", "fr_fr: foo"]
+        expect(collection.to_a).to eq ["en: bar", "fr: foo"]
       end
     end
   end

--- a/spec/lib/i18n/hygiene/keys_with_return_symbol_spec.rb
+++ b/spec/lib/i18n/hygiene/keys_with_return_symbol_spec.rb
@@ -3,7 +3,7 @@ require 'i18n/hygiene'
 
 describe I18n::Hygiene::KeysWithReturnSymbol do
   describe "#to_a" do
-    let(:locales) { [:en, :fr_fr] }
+    let(:locales) { [:en, :fr] }
     let(:keys_to_check) { %w[foo bar] }
     let(:i18n_wrapper) { instance_double(I18n::Hygiene::Wrapper, locales: locales, keys_to_check: keys_to_check) }
     let(:collection) { I18n::Hygiene::KeysWithReturnSymbol.new(i18n_wrapper: i18n_wrapper) }
@@ -11,12 +11,12 @@ describe I18n::Hygiene::KeysWithReturnSymbol do
     before do
       allow(i18n_wrapper).to receive(:value).with(:en, "foo") { "one two" }
       allow(i18n_wrapper).to receive(:value).with(:en, "bar") { "one \u23ce two" }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "foo") { "one \u23ce two" }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "bar") { "one two" }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "foo") { "one \u23ce two" }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "bar") { "one two" }
     end
 
     it "returns keys that include return symbol" do
-      expect(collection.to_a).to eq ["en: bar", "fr_fr: foo"]
+      expect(collection.to_a).to eq ["en: bar", "fr: foo"]
     end
   end
 end

--- a/spec/lib/i18n/hygiene/keys_with_script_tags_spec.rb
+++ b/spec/lib/i18n/hygiene/keys_with_script_tags_spec.rb
@@ -3,7 +3,7 @@ require 'i18n/hygiene'
 
 describe I18n::Hygiene::KeysWithScriptTags do
   describe "#to_a" do
-    let(:locales) { [:en, :fr_fr] }
+    let(:locales) { [:en, :fr] }
     let(:keys_to_check) { %w[foo bar] }
     let(:i18n_wrapper) { instance_double(I18n::Hygiene::Wrapper, locales: locales, keys_to_check: keys_to_check) }
     let(:collection) { I18n::Hygiene::KeysWithScriptTags.new(i18n_wrapper: i18n_wrapper) }
@@ -11,12 +11,12 @@ describe I18n::Hygiene::KeysWithScriptTags do
     before do
       allow(i18n_wrapper).to receive(:value).with(:en, "foo") { "one two" }
       allow(i18n_wrapper).to receive(:value).with(:en, "bar") { "<script>one two</script>" }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "foo") { "<script>one two</script>" }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "bar") { "one two" }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "foo") { "<script>one two</script>" }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "bar") { "one two" }
     end
 
     it "returns keys that include script tags" do
-      expect(collection.to_a).to eq(["en: bar", "fr_fr: foo"])
+      expect(collection.to_a).to eq(["en: bar", "fr: foo"])
     end
   end
 end

--- a/spec/lib/i18n/hygiene/variable_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/variable_checker_spec.rb
@@ -11,7 +11,7 @@ describe I18n::Hygiene::VariableChecker do
   let(:matching_js_value) { "Translation with correct variable __variable_key__"  }
   let(:mismatch) { "Translation with wrong variable %{bad_key}" }
   let(:mismatch_js) { "Translation with wrong variable __bad_key__" }
-  let(:mismatch_info) { "test_key for locale fr_fr is missing interpolation variable(s): variable_key"  }
+  let(:mismatch_info) { "test_key for locale fr is missing interpolation variable(s): variable_key"  }
   let(:markdown_italic_en) { "Within Markdown __italics__ ignore" }
   let(:markdown_italic_fr) { "Within Markdown __italiques__ ignore" }
 
@@ -19,49 +19,49 @@ describe I18n::Hygiene::VariableChecker do
   describe '#mismatched_variables_found?' do
     it 'returns true if a mismatched variable is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr_fr, "test_key") { true }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "test_key") { mismatch }
+      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { mismatch }
       expect(checker.mismatched_variables_found?).to be true
     end
 
     it 'returns true if a mismatched variable using JS syntax is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_js_value }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr_fr, "test_key") { true }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "test_key") { mismatch_js }
+      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { mismatch_js }
       expect(checker.mismatched_variables_found?).to be true
     end
 
     it 'returns false if no mismatched variable is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr_fr, "test_key") { true }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "test_key") { matching_value }
+      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { matching_value }
       expect(checker.mismatched_variables_found?).to be false
     end
 
     it 'returns false if no mismatched variable using JS syntax is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_js_value }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr_fr, "test_key") { true }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "test_key") { matching_js_value }
+      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { matching_js_value }
       expect(checker.mismatched_variables_found?).to be false
     end
 
     it 'returns false if markdown italics used in key with "_markdown" suffix' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key_markdown") { markdown_italic_en }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr_fr, "test_key_markdown") { true }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "test_key_markdown") { markdown_italic_fr }
+      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key_markdown") { true }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "test_key_markdown") { markdown_italic_fr }
       expect(checker_markdown.mismatched_variables_found?).to be false
     end
 
     it 'returns true if markdown italics used in key with non "_markdown" suffix' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { markdown_italic_en }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr_fr, "test_key") { true }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "test_key") { markdown_italic_fr }
+      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { markdown_italic_fr }
       expect(checker.mismatched_variables_found?).to be true
     end
 
     it 'returns false if key not defined in locale' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr_fr, "test_key") { false }
+      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { false }
       expect(checker.mismatched_variables_found?).to be false
     end
   end
@@ -69,15 +69,15 @@ describe I18n::Hygiene::VariableChecker do
   describe '#mismatch_details' do
     it 'returns expected report if a mismatched variable is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr_fr, "test_key") { true }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "test_key") { mismatch }
+      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { mismatch }
       expect(checker.mismatch_details).to eq(mismatch_info)
     end
 
     it 'returns "No mismatches found" if no mismatched variable is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr_fr, "test_key") { true }
-      allow(i18n_wrapper).to receive(:value).with(:fr_fr, "test_key") { matching_value }
+      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { matching_value }
       expect(checker.mismatch_details).to eq("test_key: no missing interpolation variables found.")
     end
   end


### PR DESCRIPTION
The i18n hygiene checks were causing some havoc over in this [PR](https://github.com/conversation/tc-analytics/pull/463), as the locale is hardcoded in the i18n gem here. It still is, but this makes the necessary changes based on the locale renaming I'm doing across the board. I will update the Gemfile in tc-analytics to point to the git version rather than the gem version.
