### PR TITLE
Ensure i18n-hygiene check compatibility with rails-i18n gem

### DIFF
--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -19,7 +19,7 @@ module I18n
       end
 
       def used_in_codebase?
-        fully_qualified_key_used?
+        fully_qualified_key_used? || i18n_config_key?
       end
 
       def fully_qualified_key_used?(given_key = key)
@@ -38,6 +38,10 @@ module I18n
         else
           return "ack --type-add=js=.coffee"
         end
+      end
+
+      def i18n_config_key?
+        key.starts_with?("i18n.")
       end
 
       def pluralized_key_used?(key)

--- a/lib/i18n/hygiene/wrapper.rb
+++ b/lib/i18n/hygiene/wrapper.rb
@@ -21,7 +21,7 @@ module I18n
 
       def value(locale, key)
         I18n.with_locale(locale) do
-          I18n.t(key)
+          I18n.t(key, resolve: false)
         end
       end
 


### PR DESCRIPTION
This PR in [analytics](https://github.com/conversation/tc-analytics/pull/466), and an incoming PR on donations both rely on this. They are adding the rails-18n gem to give us more flexibility as we add more locales. These two issues being fixed here were also present in the change made to TC, but this gem is not yet in TC, here is the [PR with the changes](https://github.com/conversation/tc/pull/6340). 

This PR is doing two things: 

- Ignore keys starting with i18n, as the i18n gem optionally uses the namespace to store locale specific config; and,
- Prevents an exception when key resolves to a proc, as a regular call to I18n.t("i18n.plural.rule") will attempt to call the proc, thus raising an error.

To test this out checkout this [PR in analytics](https://github.com/conversation/tc-analytics/pull/466) and run `be rake i18n:hygiene:all`.
You should get some exceptions. Then change the path in Gemfile to look at your locale copy of this (for me this is `gem 'i18n-hygiene', path: '/Users/eleanorkh/dev/i18n-hygiene'`. Make sure you've got this branch checked out and then run `be rake i18n:hygiene:all`. It _should_ pass!