### PR TITLE
Mild refactor of key usage checker

### DIFF
--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -26,7 +26,7 @@ module I18n
         if pluralized_key_used?(key)
           fully_qualified_key_used?(without_last_part(key))
         else
-          %x<#{ag_or_ack} #{key} app lib | wc -l>.strip.to_i > 0
+          %x<#{ag_or_ack} #{key} #{@directories.join(" ")} | wc -l>.strip.to_i > 0
         end
       end
 

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -17,7 +17,7 @@ module I18n
       end
 
       def used?(key)
-        fully_qualified_key_used?(key) || i18n_config_key?(key)
+        i18n_config_key?(key) || fully_qualified_key_used?(key)
       end
 
       private

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -12,23 +12,21 @@ module I18n
     # which should also be configurable.
     class KeyUsageChecker
 
-      attr_reader :key
-
-      def initialize(key)
-        @key = key
+      def initialize(directories:)
+        @directories = directories
       end
 
-      def used_in_codebase?
-        fully_qualified_key_used? || i18n_config_key?
+      def used?(key)
+        fully_qualified_key_used?(key) || i18n_config_key?(key)
       end
 
       private
 
-      def fully_qualified_key_used?(given_key = key)
-        if pluralized_key_used?(given_key)
-          fully_qualified_key_used?(without_last_part)
+      def fully_qualified_key_used?(key)
+        if pluralized_key_used?(key)
+          fully_qualified_key_used?(without_last_part(key))
         else
-          %x<#{ag_or_ack} #{given_key} app lib | wc -l>.strip.to_i > 0
+          %x<#{ag_or_ack} #{key} app lib | wc -l>.strip.to_i > 0
         end
       end
 
@@ -40,7 +38,7 @@ module I18n
         end
       end
 
-      def i18n_config_key?
+      def i18n_config_key?(key)
         key.starts_with?("i18n.")
       end
 
@@ -48,7 +46,7 @@ module I18n
         [ "zero", "one", "other" ].include?(key.split(".").last)
       end
 
-      def without_last_part
+      def without_last_part(key)
         key.split(".")[0..-2].join(".")
       end
 

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -22,6 +22,8 @@ module I18n
         fully_qualified_key_used? || i18n_config_key?
       end
 
+      private
+
       def fully_qualified_key_used?(given_key = key)
         if pluralized_key_used?(given_key)
           fully_qualified_key_used?(without_last_part)
@@ -29,8 +31,6 @@ module I18n
           %x<#{ag_or_ack} #{given_key} app lib | wc -l>.strip.to_i > 0
         end
       end
-
-      private
 
       def ag_or_ack
         if %x<which ag | wc -l>.strip.to_i == 1

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -39,7 +39,7 @@ module I18n
       end
 
       def i18n_config_key?(key)
-        key.starts_with?("i18n.")
+        key.start_with?("i18n.")
       end
 
       def pluralized_key_used?(key)

--- a/lib/tasks/i18n_hygiene.rake
+++ b/lib/tasks/i18n_hygiene.rake
@@ -11,8 +11,10 @@ namespace :i18n do
       puts "Checking usage of EN keys..."
       puts "(Please be patient while the codebase is searched for key usage)"
 
+      key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(directories: ["app", "lib"])
+
       unused_keys = Parallel.map(I18n::Hygiene::Wrapper.new.keys_to_check) { |key|
-        key unless I18n::Hygiene::KeyUsageChecker.new(key).used_in_codebase?
+        key unless key_usage_checker.used?(key)
       }.compact
 
       unused_keys.each do |key|

--- a/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
@@ -2,49 +2,51 @@ require 'i18n/hygiene/key_usage_checker'
 
 describe I18n::Hygiene::KeyUsageChecker do
 
-  let(:checker_instance) { I18n::Hygiene::KeyUsageChecker.new(directories: ["yolo"]) }
-
-  # stub system calls to ack/ag and wc
-  before do
-    allow(checker_instance).to receive(:ag_or_ack).and_return("ag")
-    allow(checker_instance).to receive(:`).and_return(wc_result)
-  end
+  let(:checker_instance) { I18n::Hygiene::KeyUsageChecker.new(directories: ["you", "only", "yolo", "once"]) }
 
   describe '#used?' do
-    context "wc is zero" do
-      let(:wc_result) { "0" }
-
-      it "returns false" do
-        expect(checker_instance.used?("my.key")).to eql false
-      end
-
-      context "key is prefixed with i18n" do
-        it "returns true" do
-          expect(checker_instance.used?("i18n.my.key")).to eql true
-        end
-      end
-
-      context "key with recongised plural suffix" do
-        it "chops plural suffix off and returns false" do
-          expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key.zero").and_call_original.ordered
-          expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key").and_call_original.ordered
-          expect(checker_instance.used?("my.key.zero")).to eql false
-        end
+    context "key is prefixed with i18n" do
+      it "returns true" do
+        expect(checker_instance.used?("i18n.my.key")).to eql true
       end
     end
 
-    context "wc is greater than zero" do
-      let(:wc_result) { "3" }
-
-      it "returns true" do
-        expect(checker_instance.used?("my.key")).to eql true
+    context "shelling out" do
+      # stub system calls to ack/ag and wc
+      before do
+        allow(checker_instance).to receive(:ag_or_ack).and_return("ag")
+        expect(checker_instance).to receive(:`).with("ag my.key you only yolo once | wc -l").and_return(wc_result)
       end
 
-      context "key with recongised plural suffix" do
-        it "chops plural suffix off and returns true" do
-          expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key.zero").and_call_original.ordered
-          expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key").and_call_original.ordered
-          expect(checker_instance.used?("my.key.zero")).to eql true
+      context "wc is zero" do
+        let(:wc_result) { "0" }
+
+        it "returns false" do
+          expect(checker_instance.used?("my.key")).to eql false
+        end
+
+        context "key with recongised plural suffix" do
+          it "chops plural suffix off and returns false" do
+            expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key.zero").and_call_original.ordered
+            expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key").and_call_original.ordered
+            expect(checker_instance.used?("my.key.zero")).to eql false
+          end
+        end
+      end
+
+      context "wc is greater than zero" do
+        let(:wc_result) { "3" }
+
+        it "returns true" do
+          expect(checker_instance.used?("my.key")).to eql true
+        end
+
+        context "key with recongised plural suffix" do
+          it "chops plural suffix off and returns true" do
+            expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key.zero").and_call_original.ordered
+            expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key").and_call_original.ordered
+            expect(checker_instance.used?("my.key.zero")).to eql true
+          end
         end
       end
     end

--- a/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
@@ -1,15 +1,52 @@
-require 'i18n'
-require 'i18n/hygiene'
+require 'i18n/hygiene/key_usage_checker'
 
 describe I18n::Hygiene::KeyUsageChecker do
 
-  describe '#used_in_codebase?' do
-    it 'finds usage of fully qualified key'
+  let(:checker_instance) { I18n::Hygiene::KeyUsageChecker.new(directories: ["yolo"]) }
 
-    it 'finds dynamic usage of key'
+  # stub system calls to ack/ag and wc
+  before do
+    allow(checker_instance).to receive(:ag_or_ack).and_return("ag")
+    allow(checker_instance).to receive(:`).and_return(wc_result)
+  end
 
-    it 'finds usage of pluralized key'
+  describe '#used?' do
+    context "wc is zero" do
+      let(:wc_result) { "0" }
 
-    it 'does not find unused key'
+      it "returns false" do
+        expect(checker_instance.used?("my.key")).to eql false
+      end
+
+      context "key is prefixed with i18n" do
+        it "returns true" do
+          expect(checker_instance.used?("i18n.my.key")).to eql true
+        end
+      end
+
+      context "key with recongised plural suffix" do
+        it "chops plural suffix off and returns false" do
+          expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key.zero").and_call_original.ordered
+          expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key").and_call_original.ordered
+          expect(checker_instance.used?("my.key.zero")).to eql false
+        end
+      end
+    end
+
+    context "wc is greater than zero" do
+      let(:wc_result) { "3" }
+
+      it "returns true" do
+        expect(checker_instance.used?("my.key")).to eql true
+      end
+
+      context "key with recongised plural suffix" do
+        it "chops plural suffix off and returns true" do
+          expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key.zero").and_call_original.ordered
+          expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key").and_call_original.ordered
+          expect(checker_instance.used?("my.key.zero")).to eql true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This branch prepares to add a class which will build a rake task for checking key usage, but it needed a bit of work first. This does a little refactor which keeps the behaviour the same and adds some tests which were previously missing.

The gist of the changes are:
- smaller surface area for `KeyUsageChecker` (only one public method)
- data which stays the same (directories) each time is passed into the constructor
- data which changes (keys) is passed into the public instance method
- reuse the same instance, rather than creating a new one each iteration