### PR TITLE
Configurable directories

### DIFF
--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -1,0 +1,36 @@
+require 'parallel'
+require 'i18n/hygiene/wrapper'
+require 'i18n/hygiene/checks/base'
+require 'i18n/hygiene/key_usage_checker'
+require 'i18n/hygiene/result'
+
+module I18n
+  module Hygiene
+    module Checks
+      class KeyUsage < Base
+        def run
+          puts "Checking usage of EN keys..."
+          puts "(Please be patient while the codebase is searched for key usage)"
+
+          key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(directories: config.directories)
+
+          unused_keys = Parallel.map(I18n::Hygiene::Wrapper.new.keys_to_check) { |key|
+            key unless key_usage_checker.used?(key)
+          }.compact
+
+          unused_keys.each do |key|
+            puts "#{key} is unused."
+          end
+
+          puts "Finished checking.\n\n"
+
+          if unused_keys.any?
+            yield Result.new(:failure)
+          else
+            yield Result.new(:pass)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -1,6 +1,7 @@
 module I18n
   module Hygiene
     class Config
+      attr_accessor :directories
       attr_accessor :locales
     end
   end

--- a/lib/i18n/hygiene/rake_task.rb
+++ b/lib/i18n/hygiene/rake_task.rb
@@ -2,12 +2,14 @@ require 'rake'
 require 'rake/tasklib'
 require 'i18n/hygiene/config'
 require 'i18n/hygiene/reporter'
+require 'i18n/hygiene/checks/key_usage'
 require 'i18n/hygiene/checks/missing_interpolation_variable'
 
 module I18n
   module Hygiene
     class RakeTask < ::Rake::TaskLib
       CHECKS = [
+        I18n::Hygiene::Checks::KeyUsage,
         I18n::Hygiene::Checks::MissingInterpolationVariable
       ]
 

--- a/spec/lib/i18n/hygiene/checks/key_usage_spec.rb
+++ b/spec/lib/i18n/hygiene/checks/key_usage_spec.rb
@@ -1,0 +1,24 @@
+require 'i18n/hygiene/config'
+require 'i18n/hygiene/checks/key_usage'
+
+RSpec.describe I18n::Hygiene::Checks::KeyUsage do
+  let(:config) { I18n::Hygiene::Config.new.tap { |config| config.directories = ["app", "lib"] } }
+  let(:instance) { I18n::Hygiene::Checks::KeyUsage.new(config) }
+  let(:wrapper_double) { instance_double(I18n::Hygiene::Wrapper, keys_to_check: ["blah"]) }
+  let(:key_usage_checker_double) { instance_double(I18n::Hygiene::KeyUsageChecker, used?: true) }
+
+  describe "#run" do
+    before do
+      allow(I18n::Hygiene::Wrapper).to receive(:new).and_return wrapper_double
+    end
+
+    it "checks for missing interpolation variables in the configured locales" do
+      expect(I18n::Hygiene::KeyUsageChecker).to receive(:new)
+        .with(directories: ["app", "lib"]).and_return key_usage_checker_double
+
+      instance.run do |result|
+        expect(result.passed?).to eq true
+      end
+    end
+  end
+end

--- a/spec/lib/i18n/hygiene/config_spec.rb
+++ b/spec/lib/i18n/hygiene/config_spec.rb
@@ -9,4 +9,11 @@ RSpec.describe I18n::Hygiene::Config do
       expect(config.locales).to eq [:en]
     end
   end
+
+  describe "#directories=" do
+    it "sets directories" do
+      config.directories = ["app", "lib"]
+      expect(config.directories).to eq ["app", "lib"]
+    end
+  end
 end


### PR DESCRIPTION
This adds a configuration for directories, and makes use of it in a new `KeyUsage` check. Which is a wrapper for the existing code that lives in the `check_key_usage` rake task.