### PR TITLE
Add key whitelist

### DIFF
--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -12,7 +12,10 @@ module I18n
           puts "Checking usage of EN keys..."
           puts "(Please be patient while the codebase is searched for key usage)"
 
-          key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(directories: config.directories)
+          key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(
+            directories: config.directories,
+            whitelist: config.whitelist
+          )
 
           unused_keys = Parallel.map(I18n::Hygiene::Wrapper.new.keys_to_check) { |key|
             key unless key_usage_checker.used?(key)

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -3,6 +3,7 @@ module I18n
     class Config
       attr_writer :directories
       attr_writer :locales
+      attr_writer :whitelist
 
       def directories
         @directories ||= []
@@ -10,6 +11,10 @@ module I18n
 
       def locales
         @locales ||= []
+      end
+
+      def whitelist
+        @whitelist ||= []
       end
     end
   end

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -1,8 +1,16 @@
 module I18n
   module Hygiene
     class Config
-      attr_accessor :directories
-      attr_accessor :locales
+      attr_writer :directories
+      attr_writer :locales
+
+      def directories
+        @directories ||= []
+      end
+
+      def locales
+        @locales ||= []
+      end
     end
   end
 end

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -12,15 +12,20 @@ module I18n
     # which should also be configurable.
     class KeyUsageChecker
 
-      def initialize(directories:)
+      def initialize(directories:, whitelist:)
         @directories = directories
+        @whitelist = whitelist
       end
 
       def used?(key)
-        i18n_config_key?(key) || fully_qualified_key_used?(key)
+        whitelisted?(key) || i18n_config_key?(key) || fully_qualified_key_used?(key)
       end
 
       private
+
+      def whitelisted?(key)
+        @whitelist.include?(key)
+      end
 
       def fully_qualified_key_used?(key)
         if pluralized_key_used?(key)

--- a/lib/tasks/i18n_hygiene.rake
+++ b/lib/tasks/i18n_hygiene.rake
@@ -11,7 +11,7 @@ namespace :i18n do
       puts "Checking usage of EN keys..."
       puts "(Please be patient while the codebase is searched for key usage)"
 
-      key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(directories: ["app", "lib"])
+      key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(directories: ["app", "lib"], whitelist: [])
 
       unused_keys = Parallel.map(I18n::Hygiene::Wrapper.new.keys_to_check) { |key|
         key unless key_usage_checker.used?(key)

--- a/spec/lib/i18n/hygiene/checks/key_usage_spec.rb
+++ b/spec/lib/i18n/hygiene/checks/key_usage_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe I18n::Hygiene::Checks::KeyUsage do
 
     it "checks for missing interpolation variables in the configured locales" do
       expect(I18n::Hygiene::KeyUsageChecker).to receive(:new)
-        .with(directories: ["app", "lib"]).and_return key_usage_checker_double
+        .with(directories: ["app", "lib"], whitelist: []).and_return key_usage_checker_double
 
       instance.run do |result|
         expect(result.passed?).to eq true

--- a/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
@@ -2,9 +2,20 @@ require 'i18n/hygiene/key_usage_checker'
 
 describe I18n::Hygiene::KeyUsageChecker do
 
-  let(:checker_instance) { I18n::Hygiene::KeyUsageChecker.new(directories: ["you", "only", "yolo", "once"]) }
+  let(:checker_instance) do
+    I18n::Hygiene::KeyUsageChecker.new(
+      directories: ["you", "only", "yolo", "once"],
+      whitelist: ["whitelisted.key"]
+    )
+  end
 
   describe '#used?' do
+    context "key is whitelisted" do
+      it "returns true" do
+        expect(checker_instance.used?("whitelisted.key")).to eql true
+      end
+    end
+
     context "key is prefixed with i18n" do
       it "returns true" do
         expect(checker_instance.used?("i18n.my.key")).to eql true


### PR DESCRIPTION
This adds a configuration to allow whitelisting of keys, and modifies to KeyUsageChecker to consider any key in that whitelist as being "used".