### PR TITLE
Make LocaleTranslations KEYS_TO_SKIP configurable

### DIFF
--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -17,7 +17,7 @@ module I18n
             whitelist: config.whitelist
           )
 
-          unused_keys = Parallel.map(I18n::Hygiene::Wrapper.new.keys_to_check) { |key|
+          unused_keys = Parallel.map(I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip).keys_to_check) { |key|
             key unless key_usage_checker.used?(key)
           }.compact
 

--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -10,7 +10,7 @@ module I18n
         def run
           puts "Checking for mismatching interpolation variables..."
 
-          wrapper = I18n::Hygiene::Wrapper.new
+          wrapper = I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip)
 
           mismatched_variables = wrapper.keys_to_check.select do |key|
             checker = I18n::Hygiene::VariableChecker.new(key, wrapper, config.locales)

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -4,6 +4,7 @@ module I18n
       attr_writer :directories
       attr_writer :locales
       attr_writer :whitelist
+      attr_writer :keys_to_skip
 
       def directories
         @directories ||= []
@@ -15,6 +16,10 @@ module I18n
 
       def whitelist
         @whitelist ||= []
+      end
+      
+      def keys_to_skip
+        @keys_to_skip ||= []
       end
     end
   end

--- a/lib/i18n/hygiene/keys_with_matched_value.rb
+++ b/lib/i18n/hygiene/keys_with_matched_value.rb
@@ -6,7 +6,7 @@ module I18n
 
       def initialize(regex, i18n_wrapper = nil, reject_keys: nil)
         @regex = regex
-        @i18n = i18n_wrapper || I18n::Hygiene::Wrapper.new
+        @i18n = i18n_wrapper || I18n::Hygiene::Wrapper.new(keys_to_skip: [])
         @reject_keys = reject_keys
         @matching_keys = load_matching_keys
       end

--- a/lib/i18n/hygiene/locale_translations.rb
+++ b/lib/i18n/hygiene/locale_translations.rb
@@ -10,9 +10,9 @@ module I18n
       # These are i18n keys provided by Rails. We cannot exclude them at the :helpers
       # scope level because we do have some TC i18n keys scoped within :helpers.
 
-      def initialize(translations, keys_to_skip: [])
+      def initialize(translations, keys_to_skip:)
         @translations = translations
-        @keys_to_skip = keys_to_skip
+        @keys_to_skip = keys_to_skip || []
       end
 
       def keys_to_check

--- a/lib/i18n/hygiene/locale_translations.rb
+++ b/lib/i18n/hygiene/locale_translations.rb
@@ -10,7 +10,7 @@ module I18n
       # These are i18n keys provided by Rails. We cannot exclude them at the :helpers
       # scope level because we do have some TC i18n keys scoped within :helpers.
 
-      def initialize(translations, keys_to_skip:)
+      def initialize(translations:, keys_to_skip:)
         @translations = translations
         @keys_to_skip = keys_to_skip || []
       end

--- a/lib/i18n/hygiene/locale_translations.rb
+++ b/lib/i18n/hygiene/locale_translations.rb
@@ -10,21 +10,14 @@ module I18n
       # These are i18n keys provided by Rails. We cannot exclude them at the :helpers
       # scope level because we do have some TC i18n keys scoped within :helpers.
 
-      # TODO: make this configurable
-      KEYS_TO_SKIP = [
-        "helpers.select.prompt",
-        "helpers.submit.create",
-        "helpers.submit.submit",
-        "helpers.submit.update"
-      ]
-
-      def initialize(translations)
+      def initialize(translations, keys_to_skip: [])
         @translations = translations
+        @keys_to_skip = keys_to_skip
       end
 
       def keys_to_check
         fully_qualified_keys(translations_to_check).reject { |key|
-          KEYS_TO_SKIP.include?(key) || EXAMPLE_KEY == key
+          keys_to_skip.include?(key) || EXAMPLE_KEY == key
         }.sort
       end
 
@@ -56,6 +49,10 @@ module I18n
 
       def scopes_from_faker
         [ :faker ]
+      end
+
+      def keys_to_skip
+        @keys_to_skip
       end
 
       def fully_qualified_keys(hash)

--- a/lib/i18n/hygiene/wrapper.rb
+++ b/lib/i18n/hygiene/wrapper.rb
@@ -13,7 +13,7 @@ module I18n
       end
 
       def keys_to_check(locale = :en)
-        I18n::Hygiene::LocaleTranslations.new(translations[locale], keys_to_skip: keys_to_skip).keys_to_check
+        I18n::Hygiene::LocaleTranslations.new(translations: translations[locale], keys_to_skip: keys_to_skip).keys_to_check
       end
 
       def locales

--- a/lib/i18n/hygiene/wrapper.rb
+++ b/lib/i18n/hygiene/wrapper.rb
@@ -8,8 +8,12 @@ module I18n
     # queryable.
     class Wrapper
 
+      def initialize(keys_to_skip:)
+        @keys_to_skip = keys_to_skip
+      end
+
       def keys_to_check(locale = :en)
-        I18n::Hygiene::LocaleTranslations.new(translations[locale]).keys_to_check
+        I18n::Hygiene::LocaleTranslations.new(translations[locale], keys_to_skip: keys_to_skip).keys_to_check
       end
 
       def locales
@@ -37,6 +41,10 @@ module I18n
 
       def load_translations
         ::I18n.backend.send(:init_translations)
+      end
+
+      def keys_to_skip
+        @keys_to_skip
       end
 
     end

--- a/spec/lib/i18n/hygiene/locale_translations_spec.rb
+++ b/spec/lib/i18n/hygiene/locale_translations_spec.rb
@@ -2,7 +2,7 @@ require 'i18n'
 require 'i18n/hygiene'
 
 describe I18n::Hygiene::LocaleTranslations do
-  let(:translations) { I18n::Hygiene::LocaleTranslations.new(all_translations, keys_to_skip: keys_to_skip) }
+  let(:translations) { I18n::Hygiene::LocaleTranslations.new(translations: all_translations, keys_to_skip: keys_to_skip) }
   let(:all_translations) do
     {
       activerecord: "abc",

--- a/spec/lib/i18n/hygiene/locale_translations_spec.rb
+++ b/spec/lib/i18n/hygiene/locale_translations_spec.rb
@@ -2,7 +2,7 @@ require 'i18n'
 require 'i18n/hygiene'
 
 describe I18n::Hygiene::LocaleTranslations do
-  let(:translations) { I18n::Hygiene::LocaleTranslations.new(all_translations) }
+  let(:translations) { I18n::Hygiene::LocaleTranslations.new(all_translations, keys_to_skip: keys_to_skip) }
   let(:all_translations) do
     {
       activerecord: "abc",
@@ -13,6 +13,14 @@ describe I18n::Hygiene::LocaleTranslations do
       foo: { bar: "baz" },
     }
   end
+  let(:keys_to_skip) {
+    [
+      "helpers.select.prompt",
+      "helpers.submit.create",
+      "helpers.submit.submit",
+      "helpers.submit.update"
+    ]
+  }
 
   describe "#keys_to_check" do
     it "excludes keys not in our control" do

--- a/spec/lib/i18n/hygiene/wrapper_spec.rb
+++ b/spec/lib/i18n/hygiene/wrapper_spec.rb
@@ -2,7 +2,7 @@ require 'i18n'
 require 'i18n/hygiene'
 
 describe I18n::Hygiene::Wrapper do
-  let(:wrapper) { I18n::Hygiene::Wrapper.new }
+  let(:wrapper) { I18n::Hygiene::Wrapper.new(keys_to_skip: []) }
 
   before do
     ::I18n.backend.send(:store_translations, :en, abuse_report: { button: { submit: "x" }})


### PR DESCRIPTION
This PR removes the hard-coded `KEYS_TO_SKIP` array constant from `LocaleTranslations` and makes the array configurable.