### PR TITLE
Allow configuration of primary locale

### DIFF
--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -17,7 +17,9 @@ module I18n
             whitelist: config.whitelist
           )
 
-          unused_keys = Parallel.map(I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip).keys_to_check) { |key|
+          wrapper = I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip)
+
+          unused_keys = Parallel.map(wrapper.keys_to_check(config.primary_locale)) { |key|
             key unless key_usage_checker.used?(key)
           }.compact
 

--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -9,7 +9,7 @@ module I18n
     module Checks
       class KeyUsage < Base
         def run
-          puts "Checking usage of EN keys..."
+          puts "Checking usage of #{config.primary_locale} keys..."
           puts "(Please be patient while the codebase is searched for key usage)"
 
           key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(

--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -12,8 +12,8 @@ module I18n
 
           wrapper = I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip)
 
-          mismatched_variables = wrapper.keys_to_check.select do |key|
-            checker = I18n::Hygiene::VariableChecker.new(key, wrapper, config.locales)
+          mismatched_variables = wrapper.keys_to_check(config.primary_locale).select do |key|
+            checker = I18n::Hygiene::VariableChecker.new(key, wrapper, config.primary_locale, config.locales)
             checker.mismatch_details if checker.mismatched_variables_found?
           end
 

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -2,12 +2,17 @@ module I18n
   module Hygiene
     class Config
       attr_writer :directories
+      attr_writer :primary_locale
       attr_writer :locales
       attr_writer :whitelist
       attr_writer :keys_to_skip
 
       def directories
         @directories ||= []
+      end
+
+      def primary_locale
+        @primary_locale ||= :en
       end
 
       def locales
@@ -17,7 +22,7 @@ module I18n
       def whitelist
         @whitelist ||= []
       end
-      
+
       def keys_to_skip
         @keys_to_skip ||= []
       end

--- a/lib/i18n/hygiene/variable_checker.rb
+++ b/lib/i18n/hygiene/variable_checker.rb
@@ -4,9 +4,10 @@ module I18n
     # as defined in :en contains an interpolation variable, the value for that key as defined
     # in any other locale must have a matching variable name.
     class VariableChecker
-      def initialize(key, i18n_wrapper, locales = [])
+      def initialize(key, i18n_wrapper, primary_locale, locales = [])
         @key = key
         @i18n_wrapper = i18n_wrapper
+        @primary_locale = primary_locale
         @locales = locales
       end
 
@@ -41,7 +42,7 @@ module I18n
       end
 
       def missing_variables(locale)
-        variables(:en).reject { |v| variables(locale).include?(v) }.join(', ')
+        variables(@primary_locale).reject { |v| variables(locale).include?(v) }.join(', ')
       end
 
       def key_defined?(locale)
@@ -49,7 +50,7 @@ module I18n
       end
 
       def variables_match?(locale)
-        variables(locale) == variables(:en)
+        variables(locale) == variables(@primary_locale)
       end
 
       def variables(locale)

--- a/lib/i18n/hygiene/wrapper.rb
+++ b/lib/i18n/hygiene/wrapper.rb
@@ -12,7 +12,7 @@ module I18n
         @keys_to_skip = keys_to_skip
       end
 
-      def keys_to_check(locale = :en)
+      def keys_to_check(locale)
         I18n::Hygiene::LocaleTranslations.new(translations: translations[locale], keys_to_skip: keys_to_skip).keys_to_check
       end
 

--- a/lib/tasks/i18n_hygiene.rake
+++ b/lib/tasks/i18n_hygiene.rake
@@ -40,7 +40,7 @@ namespace :i18n do
       wrapper = I18n::Hygiene::Wrapper.new
 
       mismatched_variables = wrapper.keys_to_check.select do |key|
-        checker = I18n::Hygiene::VariableChecker.new(key, wrapper, [:fr])
+        checker = I18n::Hygiene::VariableChecker.new(key, wrapper, :en, [:fr])
         checker.mismatch_details if checker.mismatched_variables_found?
       end
 

--- a/spec/fixtures/Rakefile
+++ b/spec/fixtures/Rakefile
@@ -5,12 +5,18 @@ I18n.load_path = Dir["spec/fixtures/locales/*.yml"]
 I18n.backend.load_translations
 
 I18n::Hygiene::RakeTask.new(:valid) do |config|
+  I18n.default_locale = :en_valid
+
   config.directories = ["spec/fixtures/project/app", "spec/fixtures/project/lib"]
+  config.primary_locale = :en_valid
   config.locales = [:fr_valid]
   config.whitelist = "translation.dynamic"
 end
 
 I18n::Hygiene::RakeTask.new(:invalid) do |config|
+  I18n.default_locale = :en_valid
+
   config.directories = ["spec/fixtures/project/app", "spec/fixtures/project/lib"]
+  config.primary_locale = :en_valid
   config.locales = [:fr_invalid]
 end

--- a/spec/fixtures/locales/en_valid.yml
+++ b/spec/fixtures/locales/en_valid.yml
@@ -1,4 +1,4 @@
-en:
+en_valid:
   translation:
     dynamic: "foo"
     plural:

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "i18n-hygiene" do
         expect {
           system("#{shell_cmd} 2> /dev/null")
         }.to output(<<~MESSAGE).to_stdout_from_any_process
-          Checking usage of EN keys...
+          Checking usage of en_valid keys...
           (Please be patient while the codebase is searched for key usage)
           translation.dynamic is unused.
           Finished checking.

--- a/spec/lib/i18n/hygiene/checks/missing_interpolation_variable_spec.rb
+++ b/spec/lib/i18n/hygiene/checks/missing_interpolation_variable_spec.rb
@@ -2,7 +2,7 @@ require 'i18n/hygiene/config'
 require 'i18n/hygiene/checks/missing_interpolation_variable'
 
 RSpec.describe I18n::Hygiene::Checks::MissingInterpolationVariable do
-  let(:config) { I18n::Hygiene::Config.new.tap { |config| config.locales = [:en, :es, :fr] } }
+  let(:config) { I18n::Hygiene::Config.new.tap { |config| config.locales = [:es, :fr] } }
   let(:instance) { I18n::Hygiene::Checks::MissingInterpolationVariable.new(config) }
   let(:wrapper_double) { instance_double(I18n::Hygiene::Wrapper, keys_to_check: ["blah"]) }
   let(:variable_checker_double) { instance_double(I18n::Hygiene::VariableChecker, mismatched_variables_found?: false) }
@@ -14,7 +14,7 @@ RSpec.describe I18n::Hygiene::Checks::MissingInterpolationVariable do
 
     it "checks for missing interpolation variables in the configured locales" do
       expect(I18n::Hygiene::VariableChecker).to receive(:new)
-        .with(String, wrapper_double, [:en, :es, :fr]).and_return variable_checker_double
+        .with(String, wrapper_double, :en, [:es, :fr]).and_return variable_checker_double
 
       instance.run do |result|
         expect(result.passed?).to eq true

--- a/spec/lib/i18n/hygiene/config_spec.rb
+++ b/spec/lib/i18n/hygiene/config_spec.rb
@@ -3,6 +3,13 @@ require 'i18n/hygiene/config'
 RSpec.describe I18n::Hygiene::Config do
   let(:config) { I18n::Hygiene::Config.new }
 
+  describe "#primary_locale=" do
+    it "sets primary_locale" do
+      config.primary_locale = :en
+      expect(config.primary_locale).to eq :en
+    end
+  end
+
   describe "#locales=" do
     it "sets locales" do
       config.locales = [:en]

--- a/spec/lib/i18n/hygiene/variable_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/variable_checker_spec.rb
@@ -3,8 +3,8 @@ require 'i18n/hygiene'
 
 describe I18n::Hygiene::VariableChecker do
   let(:i18n_wrapper) { instance_double("TC::I18nWrapper") }
-  let(:checker) { I18n::Hygiene::VariableChecker.new("test_key", i18n_wrapper, [:fr]) }
-  let(:checker_markdown) { I18n::Hygiene::VariableChecker.new("test_key_markdown", i18n_wrapper, [:fr]) }
+  let(:checker) { I18n::Hygiene::VariableChecker.new("test_key", i18n_wrapper, :en, [:fr]) }
+  let(:checker_markdown) { I18n::Hygiene::VariableChecker.new("test_key_markdown", i18n_wrapper, :en, [:fr]) }
   let(:base_value) { "A sentence with a variable %{variable_key}"  }
   let(:base_js_value) { "A sentence with a variable __variable_key__"  }
   let(:matching_value) { "Translation with correct variable %{variable_key}"  }

--- a/spec/lib/i18n/hygiene/wrapper_spec.rb
+++ b/spec/lib/i18n/hygiene/wrapper_spec.rb
@@ -10,7 +10,7 @@ describe I18n::Hygiene::Wrapper do
 
   describe '#keys_to_check' do
     it 'includes expected key in those retrieved for default locale' do
-      expect(wrapper.keys_to_check).to include("abuse_report.button.submit")
+      expect(wrapper.keys_to_check(:en)).to include("abuse_report.button.submit")
     end
   end
 


### PR DESCRIPTION
This removes the last few places we hard coded :en as the primary locale.

This has revealed a few clunky bits, one being that you'll get obscure exceptions if the `primary_locale` exists, but `default_locale` (which, if not set, is `:en`) does not. Remove `I18n.default_locale = :en_valid` from the `spec/fixtures/Rakefile` and run the tests to see what I mean.

I wonder if we should throw an exception if the `primary_locale` and `default_locale` don't match/exist? 

Alternatively, because there's some coupling between those two options, maybe it's better if we drive the hygiene checks using `I18n.default_locale` and document that, rather than providing a similar sounding configuration of our own, when we still end up with a dependency on `I18n.default_locale` being set for the I18n gem to work.

cc @yob 