### PR TITLE
Improve terminal output 1

### DIFF
--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -28,7 +28,7 @@ module I18n
         private
 
         def failure_message(locale, key, missing_variables)
-          "#{key} for locale #{locale} is missing interpolation variable(s): #{missing_variables.join(", ")}"
+          "\n#{key} for locale #{locale} is missing interpolation variable(s): #{missing_variables.join(", ")}\n"
         end
       end
     end

--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -8,24 +8,27 @@ module I18n
     module Checks
       class MissingInterpolationVariable < Base
         def run
-          puts "Checking for mismatching interpolation variables..."
+          puts "Checking all interpolation variables present..."
 
           wrapper = I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip)
 
-          mismatched_variables = wrapper.keys_to_check(config.primary_locale).select do |key|
+          wrapper.keys_to_check(config.primary_locale).select do |key|
             checker = I18n::Hygiene::VariableChecker.new(key, wrapper, config.primary_locale, config.locales)
-            checker.mismatch_details if checker.mismatched_variables_found?
+
+            checker.mismatched_variables do |locale, key, missing_variables|
+              if missing_variables.any?
+                yield Result.new(:failure, message: failure_message(locale, key, missing_variables))
+              else
+                yield Result.new(:pass, message: ".")
+              end
+            end
           end
+        end
 
-          mismatched_variables.each { |details| puts details }
+        private
 
-          puts "Finished checking.\n\n"
-
-          if mismatched_variables.any?
-            yield Result.new(:failure)
-          else
-            yield Result.new(:pass)
-          end
+        def failure_message(locale, key, missing_variables)
+          "#{key} for locale #{locale} is missing interpolation variable(s): #{missing_variables.join(", ")}"
         end
       end
     end

--- a/lib/i18n/hygiene/reporter.rb
+++ b/lib/i18n/hygiene/reporter.rb
@@ -36,11 +36,7 @@ module I18n
       end
 
       def print_progress(result)
-        if result.message.length > 1
-          puts "\n#{Rainbow(result.message).color(result_color(result))}\n\n"
-        else
-          print Rainbow(result.message).color(result_color(result))
-        end
+        print Rainbow(result.message).color(result_color(result))
       end
     end
   end

--- a/lib/i18n/hygiene/reporter.rb
+++ b/lib/i18n/hygiene/reporter.rb
@@ -4,6 +4,8 @@ module I18n
   module Hygiene
     class Reporter
       def concat(result)
+        print_progress(result)
+
         results.push(result)
       end
 
@@ -20,6 +22,24 @@ module I18n
           puts Rainbow("i18n hygiene checks passed.").green
         else
           puts Rainbow("i18n hygiene checks failed.").red
+        end
+      end
+
+      private
+
+      def result_color(result)
+        if result.passed?
+          :green
+        else
+          :red
+        end
+      end
+
+      def print_progress(result)
+        if result.message.length > 1
+          puts "\n#{Rainbow(result.message).color(result_color(result))}\n\n"
+        else
+          print Rainbow(result.message).color(result_color(result))
         end
       end
     end

--- a/lib/i18n/hygiene/result.rb
+++ b/lib/i18n/hygiene/result.rb
@@ -1,8 +1,11 @@
 module I18n
   module Hygiene
     class Result
-      def initialize(status)
+      attr_reader :message
+
+      def initialize(status, message: "")
         @status = status
+        @message = message
       end
 
       def passed?

--- a/lib/i18n/hygiene/variable_checker.rb
+++ b/lib/i18n/hygiene/variable_checker.rb
@@ -12,9 +12,7 @@ module I18n
       end
 
       def mismatched_variables
-        @locales.each do |locale|
-          yield(locale, @key, missing_variables(locale))
-        end
+        @locales.each { |locale| yield locale, @key, missing_variables(locale) }
       end
 
       private

--- a/lib/i18n/hygiene/variable_checker.rb
+++ b/lib/i18n/hygiene/variable_checker.rb
@@ -11,38 +11,18 @@ module I18n
         @locales = locales
       end
 
-      def mismatched_variables_found?
+      def mismatched_variables
         @locales.each do |locale|
           if key_defined?(locale)
-            return true unless variables_match?(locale)
+            yield(locale, @key, missing_variables(locale)) unless variables_match?(locale)
           end
-        end
-        false
-      end
-
-      def mismatch_details
-        if mismatched_variables_found?
-          details_array = []
-          @locales.each do |locale|
-            if key_defined?(locale)
-              details_array << mismatch_details_for_locale(locale) unless variables_match?(locale)
-            end
-          end
-          details_array.each { |details| puts details }.join("\n")
-          return details_array.join("\n")
-        else
-          return "#{@key}: no missing interpolation variables found."
         end
       end
 
       private
 
-      def mismatch_details_for_locale(locale)
-        "#{@key} for locale #{locale} is missing interpolation variable(s): #{missing_variables(locale)}"
-      end
-
       def missing_variables(locale)
-        variables(@primary_locale).reject { |v| variables(locale).include?(v) }.join(', ')
+        variables(@primary_locale).reject { |v| variables(locale).include?(v) }
       end
 
       def key_defined?(locale)

--- a/lib/i18n/hygiene/variable_checker.rb
+++ b/lib/i18n/hygiene/variable_checker.rb
@@ -13,17 +13,15 @@ module I18n
 
       def mismatched_variables
         @locales.each do |locale|
-          if key_defined?(locale) && !variables_match?(locale)
-            yield(locale, @key, missing_variables(locale))
-          else
-            yield(locale, @key, [])
-          end
+          yield(locale, @key, missing_variables(locale))
         end
       end
 
       private
 
       def missing_variables(locale)
+        return [] unless key_defined?(locale)
+
         variables(@primary_locale).reject { |v| variables(locale).include?(v) }
       end
 

--- a/lib/i18n/hygiene/variable_checker.rb
+++ b/lib/i18n/hygiene/variable_checker.rb
@@ -13,8 +13,10 @@ module I18n
 
       def mismatched_variables
         @locales.each do |locale|
-          if key_defined?(locale)
-            yield(locale, @key, missing_variables(locale)) unless variables_match?(locale)
+          if key_defined?(locale) && !variables_match?(locale)
+            yield(locale, @key, missing_variables(locale))
+          else
+            yield(locale, @key, [])
           end
         end
       end

--- a/lib/i18n/hygiene/variable_checker.rb
+++ b/lib/i18n/hygiene/variable_checker.rb
@@ -29,10 +29,6 @@ module I18n
         @i18n_wrapper.key_found?(locale, @key)
       end
 
-      def variables_match?(locale)
-        variables(locale) == variables(@primary_locale)
-      end
-
       def variables(locale)
         collect_variables(@i18n_wrapper.value(locale, @key))
       end

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe "i18n-hygiene" do
           Finished checking.
 
           Checking all interpolation variables present...
-
+          .
           translation.interpolation for locale fr_invalid is missing interpolation variable(s): qux
-          Checking for phrases that contain entities but probably shouldn't...
+          ..Checking for phrases that contain entities but probably shouldn't...
           - en_invalid: translation.dynamic
           - fr_invalid: translation.full_key
           Finished checking.

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -29,10 +29,9 @@ RSpec.describe "i18n-hygiene" do
           translation.dynamic is unused.
           Finished checking.
 
-          Checking for mismatching interpolation variables...
+          Checking all interpolation variables present...
+
           translation.interpolation for locale fr_invalid is missing interpolation variable(s): qux
-          translation.interpolation
-          Finished checking.
 
           Checking for phrases that contain entities but probably shouldn't...
           - en_invalid: translation.dynamic

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe "i18n-hygiene" do
           Checking all interpolation variables present...
 
           translation.interpolation for locale fr_invalid is missing interpolation variable(s): qux
-
           Checking for phrases that contain entities but probably shouldn't...
           - en_invalid: translation.dynamic
           - fr_invalid: translation.full_key

--- a/spec/lib/i18n/hygiene/checks/missing_interpolation_variable_spec.rb
+++ b/spec/lib/i18n/hygiene/checks/missing_interpolation_variable_spec.rb
@@ -5,11 +5,12 @@ RSpec.describe I18n::Hygiene::Checks::MissingInterpolationVariable do
   let(:config) { I18n::Hygiene::Config.new.tap { |config| config.locales = [:es, :fr] } }
   let(:instance) { I18n::Hygiene::Checks::MissingInterpolationVariable.new(config) }
   let(:wrapper_double) { instance_double(I18n::Hygiene::Wrapper, keys_to_check: ["blah"]) }
-  let(:variable_checker_double) { instance_double(I18n::Hygiene::VariableChecker, mismatched_variables_found?: false) }
+  let(:variable_checker_double) { instance_double(I18n::Hygiene::VariableChecker) }
 
   describe "#run" do
     before do
       allow(I18n::Hygiene::Wrapper).to receive(:new).and_return wrapper_double
+      allow(variable_checker_double).to receive(:mismatched_variables)
     end
 
     it "checks for missing interpolation variables in the configured locales" do

--- a/spec/lib/i18n/hygiene/variable_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/variable_checker_spec.rb
@@ -16,70 +16,66 @@ describe I18n::Hygiene::VariableChecker do
   let(:markdown_italic_fr) { "Within Markdown __italiques__ ignore" }
 
 
-  describe '#mismatched_variables_found?' do
-    it 'returns true if a mismatched variable is found' do
+  describe '#mismatched_variables' do
+    it 'yields if a mismatched variable is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
       allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { mismatch }
-      expect(checker.mismatched_variables_found?).to be true
+
+      expect { |block| checker.mismatched_variables(&block) }.to yield_with_args(
+        :fr, "test_key", [:variable_key]
+      )
     end
 
-    it 'returns true if a mismatched variable using JS syntax is found' do
+    it 'yields if a mismatched variable using JS syntax is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_js_value }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
       allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { mismatch_js }
-      expect(checker.mismatched_variables_found?).to be true
+
+      expect { |block| checker.mismatched_variables(&block) }.to yield_with_args(
+        :fr, "test_key", [:variable_key]
+      )
     end
 
-    it 'returns false if no mismatched variable is found' do
+    it 'does not yield if no mismatched variable is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
       allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { matching_value }
-      expect(checker.mismatched_variables_found?).to be false
+
+      expect { |block| checker.mismatched_variables(&block) }.to_not yield_control
     end
 
     it 'returns false if no mismatched variable using JS syntax is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_js_value }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
       allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { matching_js_value }
-      expect(checker.mismatched_variables_found?).to be false
+
+      expect { |block| checker.mismatched_variables(&block) }.to_not yield_control
     end
 
     it 'returns false if markdown italics used in key with "_markdown" suffix' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key_markdown") { markdown_italic_en }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key_markdown") { true }
       allow(i18n_wrapper).to receive(:value).with(:fr, "test_key_markdown") { markdown_italic_fr }
-      expect(checker_markdown.mismatched_variables_found?).to be false
+
+      expect { |block| checker_markdown.mismatched_variables(&block) }.to_not yield_control
     end
 
-    it 'returns true if markdown italics used in key with non "_markdown" suffix' do
+    it 'yields if markdown italics used in key with non "_markdown" suffix' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { markdown_italic_en }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
       allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { markdown_italic_fr }
-      expect(checker.mismatched_variables_found?).to be true
+
+      expect { |block| checker.mismatched_variables(&block) }.to yield_with_args(
+        :fr, "test_key", [:italics]
+      )
     end
 
-    it 'returns false if key not defined in locale' do
+    it 'does not yield if key not defined in locale' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { false }
-      expect(checker.mismatched_variables_found?).to be false
+
+      expect { |block| checker.mismatched_variables(&block) }.to_not yield_control
     end
   end
-
-  describe '#mismatch_details' do
-    it 'returns expected report if a mismatched variable is found' do
-      allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
-      allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { mismatch }
-      expect(checker.mismatch_details).to eq(mismatch_info)
-    end
-
-    it 'returns "No mismatches found" if no mismatched variable is found' do
-      allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
-      allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
-      allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { matching_value }
-      expect(checker.mismatch_details).to eq("test_key: no missing interpolation variables found.")
-    end
-  end
-
 end

--- a/spec/lib/i18n/hygiene/variable_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/variable_checker_spec.rb
@@ -37,28 +37,34 @@ describe I18n::Hygiene::VariableChecker do
       )
     end
 
-    it 'does not yield if no mismatched variable is found' do
+    it 'yields if no mismatched variable is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
       allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { matching_value }
 
-      expect { |block| checker.mismatched_variables(&block) }.to_not yield_control
+      expect { |block| checker.mismatched_variables(&block) }.to yield_with_args(
+        :fr, "test_key", []
+      )
     end
 
-    it 'returns false if no mismatched variable using JS syntax is found' do
+    it 'yields if no mismatched variable using JS syntax is found' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_js_value }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { true }
       allow(i18n_wrapper).to receive(:value).with(:fr, "test_key") { matching_js_value }
 
-      expect { |block| checker.mismatched_variables(&block) }.to_not yield_control
+      expect { |block| checker.mismatched_variables(&block) }.to yield_with_args(
+        :fr, "test_key", []
+      )
     end
 
-    it 'returns false if markdown italics used in key with "_markdown" suffix' do
+    it 'yields if markdown italics used in key with "_markdown" suffix' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key_markdown") { markdown_italic_en }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key_markdown") { true }
       allow(i18n_wrapper).to receive(:value).with(:fr, "test_key_markdown") { markdown_italic_fr }
 
-      expect { |block| checker_markdown.mismatched_variables(&block) }.to_not yield_control
+      expect { |block| checker_markdown.mismatched_variables(&block) }.to yield_with_args(
+        :fr, "test_key_markdown", []
+      )
     end
 
     it 'yields if markdown italics used in key with non "_markdown" suffix' do
@@ -71,11 +77,13 @@ describe I18n::Hygiene::VariableChecker do
       )
     end
 
-    it 'does not yield if key not defined in locale' do
+    it 'yields if key not defined in locale' do
       allow(i18n_wrapper).to receive(:value).with(:en, "test_key") { base_value }
       allow(i18n_wrapper).to receive(:key_found?).with(:fr, "test_key") { false }
 
-      expect { |block| checker.mismatched_variables(&block) }.to_not yield_control
+      expect { |block| checker.mismatched_variables(&block) }.to yield_with_args(
+        :fr, "test_key", []
+      )
     end
   end
 end


### PR DESCRIPTION
This is part of a larger bit of work to improve the terminal output when running the rake task... however I ended up doing much more work to `VariableChecker` than I originally intended, so I've split the PR so that this branch only has the changes to `MissingInterpolationVariable`, along with a couple of changes to the reporter.

The main benefit of these changes is the ability to log progress of missing interpolation variables as it's happening. A side effect of that is that `VariableChecker` became a lot simpler, because it's no longer a two stage process of running the checks, then getting the details in a second method call.