### PR TITLE
Only shell out once to determine whether to use ag or ack

### DIFF
--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -15,6 +15,7 @@ module I18n
       def initialize(directories:, whitelist:)
         @directories = directories
         @whitelist = whitelist
+        @tool = ag_or_ack
       end
 
       def used?(key)
@@ -31,15 +32,17 @@ module I18n
         if pluralized_key_used?(key)
           fully_qualified_key_used?(without_last_part(key))
         else
-          %x<#{ag_or_ack} #{key} #{@directories.join(" ")} | wc -l>.strip.to_i > 0
+          %x<#{@tool} #{key} #{@directories.join(" ")} | wc -l>.strip.to_i > 0
         end
       end
 
       def ag_or_ack
-        if %x<which ag | wc -l>.strip.to_i == 1
+        if system("which ag > /dev/null")
           return "ag"
-        else
+        elsif system("which ack > /dev/null")
           return "ack --type-add=js=.coffee"
+        else
+          raise "Must have either ag (silversearcher-ag) or ack installed."
         end
       end
 


### PR DESCRIPTION
Also raise a helpful exception if neither exists, rather than just assuming that ack will be available if ag is not.

A moderate improvement:
```
before
real  1m5.978s
user  0m41.292s
sys 1m25.748s
```

```
after
real  0m51.758s
user  0m39.804s
sys 1m25.928s
```
