### PR TITLE
Unify whitelist and keys to skip

### DIFF
--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -12,11 +12,7 @@ module I18n
           puts "Checking usage of #{config.primary_locale} keys..."
           puts "(Please be patient while the codebase is searched for key usage)"
 
-          key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(
-            directories: config.directories,
-            whitelist: config.whitelist
-          )
-
+          key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(directories: config.directories)
           wrapper = I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip)
 
           unused_keys = Parallel.map(wrapper.keys_to_check(config.primary_locale)) { |key|

--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -10,7 +10,7 @@ module I18n
         def run
           puts "Checking for mismatching interpolation variables..."
 
-          wrapper = I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip)
+          wrapper = I18n::Hygiene::Wrapper.new
 
           mismatched_variables = wrapper.keys_to_check(config.primary_locale).select do |key|
             checker = I18n::Hygiene::VariableChecker.new(key, wrapper, config.primary_locale, config.locales)

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -4,7 +4,6 @@ module I18n
       attr_writer :directories
       attr_writer :primary_locale
       attr_writer :locales
-      attr_writer :whitelist
       attr_writer :keys_to_skip
 
       def directories
@@ -17,10 +16,6 @@ module I18n
 
       def locales
         @locales ||= []
-      end
-
-      def whitelist
-        @whitelist ||= []
       end
 
       def keys_to_skip

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -1,15 +1,6 @@
 module I18n
   module Hygiene
-    # Checks the usage of i18n keys in the TC codebase.
-    #
-    # TODO: This class needs some work, I had to strip out a bunch of functionality around
-    # the dynamically used keys because it was all specific to TC.
-    #
-    # We need to add a way to configure the hygiene checks to "whitelist" certain dynamic
-    # keys and so on.
-    #
-    # The other issue is that we hard code the folders we scan for fully qualified keys
-    # which should also be configurable.
+    # Checks the usage of i18n keys in the codebase.
     class KeyUsageChecker
 
       def initialize(directories:, whitelist:)

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -3,21 +3,16 @@ module I18n
     # Checks the usage of i18n keys in the codebase.
     class KeyUsageChecker
 
-      def initialize(directories:, whitelist:)
+      def initialize(directories:)
         @directories = directories
-        @whitelist = whitelist
         @tool = ag_or_ack
       end
 
       def used?(key)
-        whitelisted?(key) || i18n_config_key?(key) || fully_qualified_key_used?(key)
+        i18n_config_key?(key) || fully_qualified_key_used?(key)
       end
 
       private
-
-      def whitelisted?(key)
-        @whitelist.include?(key)
-      end
 
       def fully_qualified_key_used?(key)
         if pluralized_key_used?(key)

--- a/spec/fixtures/valid.Rakefile
+++ b/spec/fixtures/valid.Rakefile
@@ -9,5 +9,5 @@ I18n::Hygiene::RakeTask.new(:default) do |config|
   config.directories = ["spec/fixtures/project/app", "spec/fixtures/project/lib"]
   config.primary_locale = :en_valid
   config.locales = [:fr_valid]
-  config.whitelist = "translation.dynamic"
+  config.keys_to_skip = "translation.dynamic"
 end

--- a/spec/lib/i18n/hygiene/checks/key_usage_spec.rb
+++ b/spec/lib/i18n/hygiene/checks/key_usage_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe I18n::Hygiene::Checks::KeyUsage do
 
     it "checks for missing interpolation variables in the configured locales" do
       expect(I18n::Hygiene::KeyUsageChecker).to receive(:new)
-        .with(directories: ["app", "lib"], whitelist: []).and_return key_usage_checker_double
+        .with(directories: ["app", "lib"]).and_return key_usage_checker_double
 
       instance.run do |result|
         expect(result.passed?).to eq true

--- a/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
@@ -4,18 +4,11 @@ describe I18n::Hygiene::KeyUsageChecker do
 
   let(:checker_instance) do
     I18n::Hygiene::KeyUsageChecker.new(
-      directories: ["you", "only", "yolo", "once"],
-      whitelist: ["whitelisted.key"]
+      directories: ["you", "only", "yolo", "once"]
     )
   end
 
   describe '#used?' do
-    context "key is whitelisted" do
-      it "returns true" do
-        expect(checker_instance.used?("whitelisted.key")).to eql true
-      end
-    end
-
     context "key is prefixed with i18n" do
       it "returns true" do
         expect(checker_instance.used?("i18n.my.key")).to eql true


### PR DESCRIPTION
I've checked the codebase and concluded that we are doubling up. We really don't need the `whitelist` option. We should perhaps rename the `keys_to_skip` option to `keys_to_ignore`, and definitely ensure it is not used in `I18n::Hygiene::Checks::MissingInterpolationVariable`.