### PR TITLE
Improve terminal output 2

### DIFF
--- a/lib/i18n/hygiene/checks/html_entity.rb
+++ b/lib/i18n/hygiene/checks/html_entity.rb
@@ -8,22 +8,12 @@ module I18n
     module Checks
       class HtmlEntity < Base
         def run
-          puts "Checking for phrases that contain entities but probably shouldn't..."
-
           wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales)
 
           keys_with_entities = I18n::Hygiene::KeysWithEntities.new(i18nwrapper: wrapper)
 
           keys_with_entities.each do |key|
-            puts "- #{key}"
-          end
-
-          puts "Finished checking.\n\n"
-
-          if keys_with_entities.any?
-            yield Result.new(:failure)
-          else
-            yield Result.new(:pass)
+            yield Result.new(:failure, message: "\n#{key} has unexpected html entity.\n")
           end
         end
 

--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -15,7 +15,7 @@ module I18n
           key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(directories: config.directories)
           wrapper = I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip)
 
-          unused_keys = Parallel.map(wrapper.keys_to_check(config.primary_locale)) { |key|
+          unused_keys = Parallel.map(wrapper.keys_to_check(config.primary_locale), in_threads: config.concurrency) { |key|
             key unless key_usage_checker.used?(key)
           }.compact
 

--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -8,8 +8,6 @@ module I18n
     module Checks
       class MissingInterpolationVariable < Base
         def run
-          puts "Checking all interpolation variables present..."
-
           wrapper = I18n::Hygiene::Wrapper.new
 
           wrapper.keys_to_check(config.primary_locale).select do |key|

--- a/lib/i18n/hygiene/checks/script_tag.rb
+++ b/lib/i18n/hygiene/checks/script_tag.rb
@@ -8,20 +8,12 @@ module I18n
     module Checks
       class ScriptTag < Base
         def run
-          puts "Checking that no values contain script tags ..."
-
           wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales)
 
           keys_with_script_tags = I18n::Hygiene::KeysWithScriptTags.new(i18n_wrapper: wrapper)
 
-          keys_with_script_tags.each { |key| puts " - #{key}" }
-
-          puts "Finished checking.\n\n"
-
-          if keys_with_script_tags.any?
-            yield Result.new(:failure)
-          else
-            yield Result.new(:pass)
+          keys_with_script_tags.each do |key|
+            yield Result.new(:failure, message: "\n#{key} has unexpected script tag.\n")
           end
         end
 

--- a/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
+++ b/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
@@ -7,20 +7,10 @@ module I18n
     module Checks
       class UnexpectedReturnSymbol < Base
         def run
-          puts "Checking that no values contain return symbols i.e. U+23CE ..."
-
           keys_with_return_symbols = I18n::Hygiene::KeysWithReturnSymbol.new
 
           keys_with_return_symbols.each do |key|
-            puts "- #{key}"
-          end
-
-          puts "Finished checking.\n\n"
-
-          if keys_with_return_symbols.any?
-            yield Result.new(:failure)
-          else
-            yield Result.new(:pass)
+            yield Result.new(:failure, message: "\n#{key} has unexpected return symbol (U+23CE).\n")
           end
         end
 

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -5,6 +5,7 @@ module I18n
       attr_writer :primary_locale
       attr_writer :locales
       attr_writer :keys_to_skip
+      attr_writer :concurrency
 
       def directories
         @directories ||= []
@@ -20,6 +21,10 @@ module I18n
 
       def keys_to_skip
         @keys_to_skip ||= []
+      end
+
+      def concurrency
+        @concurrency ||= nil
       end
     end
   end

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -24,7 +24,7 @@ module I18n
       end
 
       def concurrency
-        @concurrency ||= nil
+        @concurrency
       end
     end
   end

--- a/lib/i18n/hygiene/reporter.rb
+++ b/lib/i18n/hygiene/reporter.rb
@@ -19,9 +19,9 @@ module I18n
 
       def report
         if passed?
-          puts Rainbow("i18n hygiene checks passed.").green
+          puts Rainbow("\ni18n hygiene checks passed.").green
         else
-          puts Rainbow("i18n hygiene checks failed.").red
+          puts Rainbow("\ni18n hygiene checks failed.").red
         end
       end
 

--- a/spec/fixtures/invalid.Rakefile
+++ b/spec/fixtures/invalid.Rakefile
@@ -9,4 +9,5 @@ I18n::Hygiene::RakeTask.new(:default) do |config|
   config.directories = ["spec/fixtures/project/app", "spec/fixtures/project/lib"]
   config.primary_locale = :en_invalid
   config.locales = [:fr_invalid]
+  config.concurrency = 1
 end

--- a/spec/fixtures/valid.Rakefile
+++ b/spec/fixtures/valid.Rakefile
@@ -10,4 +10,5 @@ I18n::Hygiene::RakeTask.new(:default) do |config|
   config.primary_locale = :en_valid
   config.locales = [:fr_valid]
   config.keys_to_skip = "translation.dynamic"
+  config.concurrency = 1
 end

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -35,10 +35,8 @@ RSpec.describe "i18n-hygiene" do
           fr_invalid: translation.full_key has unexpected html entity.
 
           en_invalid: translation.plural.one has unexpected script tag.
-          Checking that no values contain return symbols i.e. U+23CE ...
-          - fr_invalid: translation.full_key
-          Finished checking.
 
+          fr_invalid: translation.full_key has unexpected return symbol (U+23CE).
           i18n hygiene checks failed.
         MESSAGE
       end

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "i18n-hygiene" do
           en_invalid: translation.plural.one has unexpected script tag.
 
           fr_invalid: translation.full_key has unexpected return symbol (U+23CE).
+
           i18n hygiene checks failed.
         MESSAGE
       end

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe "i18n-hygiene" do
         }.to output(<<~MESSAGE).to_stdout_from_any_process
 
           translation.dynamic is unused.
-          ...Checking all interpolation variables present...
-          .
+          ....
           translation.interpolation for locale fr_invalid is missing interpolation variable(s): qux
           ..
           en_invalid: translation.dynamic has unexpected html entity.

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -24,12 +24,9 @@ RSpec.describe "i18n-hygiene" do
         expect {
           system("#{shell_cmd} 2> /dev/null")
         }.to output(<<~MESSAGE).to_stdout_from_any_process
-          Checking usage of en_invalid keys...
-          (Please be patient while the codebase is searched for key usage)
-          translation.dynamic is unused.
-          Finished checking.
 
-          Checking all interpolation variables present...
+          translation.dynamic is unused.
+          ...Checking all interpolation variables present...
           .
           translation.interpolation for locale fr_invalid is missing interpolation variable(s): qux
           ..Checking for phrases that contain entities but probably shouldn't...

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -33,10 +33,8 @@ RSpec.describe "i18n-hygiene" do
           en_invalid: translation.dynamic has unexpected html entity.
 
           fr_invalid: translation.full_key has unexpected html entity.
-          Checking that no values contain script tags ...
-           - en_invalid: translation.plural.one
-          Finished checking.
 
+          en_invalid: translation.plural.one has unexpected script tag.
           Checking that no values contain return symbols i.e. U+23CE ...
           - fr_invalid: translation.full_key
           Finished checking.

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -29,11 +29,10 @@ RSpec.describe "i18n-hygiene" do
           ...Checking all interpolation variables present...
           .
           translation.interpolation for locale fr_invalid is missing interpolation variable(s): qux
-          ..Checking for phrases that contain entities but probably shouldn't...
-          - en_invalid: translation.dynamic
-          - fr_invalid: translation.full_key
-          Finished checking.
+          ..
+          en_invalid: translation.dynamic has unexpected html entity.
 
+          fr_invalid: translation.full_key has unexpected html entity.
           Checking that no values contain script tags ...
            - en_invalid: translation.plural.one
           Finished checking.


### PR DESCRIPTION
This shifts the remaining Checks over to the new method of reporting as they go, rather than after they finish.

A nice side effect of this change is that there's no more rubbish when you run the specs, as all console output is now handled by the Reporter class.

The final PR will unify the messages, right now if you look at the integration specs they are all over the place. I think this is at a decent enough spot that it can be merged though.