### PR TITLE
Fix script tag checker

### DIFF
--- a/lib/i18n/hygiene/keys_with_script_tags.rb
+++ b/lib/i18n/hygiene/keys_with_script_tags.rb
@@ -7,7 +7,7 @@ module I18n
     class KeysWithScriptTags
       include Enumerable
 
-      SCRIPT_TAG_REGEX = /<script>.*<\/.*>/
+      SCRIPT_TAG_REGEX = /<script.*/
 
       def initialize(i18n_wrapper: nil)
         @matcher = I18n::Hygiene::KeysWithMatchedValue.new(SCRIPT_TAG_REGEX, i18n_wrapper)

--- a/lib/i18n/hygiene/keys_with_script_tags.rb
+++ b/lib/i18n/hygiene/keys_with_script_tags.rb
@@ -7,7 +7,7 @@ module I18n
     class KeysWithScriptTags
       include Enumerable
 
-      SCRIPT_TAG_REGEX = /<script>.*<\/script>/
+      SCRIPT_TAG_REGEX = /<script>.*<\/.*>/
 
       def initialize(i18n_wrapper: nil)
         @matcher = I18n::Hygiene::KeysWithMatchedValue.new(SCRIPT_TAG_REGEX, i18n_wrapper)

--- a/spec/lib/i18n/hygiene/keys_with_script_tags_spec.rb
+++ b/spec/lib/i18n/hygiene/keys_with_script_tags_spec.rb
@@ -4,19 +4,21 @@ require 'i18n/hygiene'
 describe I18n::Hygiene::KeysWithScriptTags do
   describe "#to_a" do
     let(:locales) { [:en, :fr] }
-    let(:keys_to_check) { %w[foo bar] }
+    let(:keys_to_check) { %w[foo bar baz] }
     let(:i18n_wrapper) { instance_double(I18n::Hygiene::Wrapper, locales: locales, keys_to_check: keys_to_check) }
     let(:collection) { I18n::Hygiene::KeysWithScriptTags.new(i18n_wrapper: i18n_wrapper) }
 
     before do
       allow(i18n_wrapper).to receive(:value).with(:en, "foo") { "one two" }
       allow(i18n_wrapper).to receive(:value).with(:en, "bar") { "<script>one two</script>" }
+      allow(i18n_wrapper).to receive(:value).with(:en, "baz") { "one two" }
       allow(i18n_wrapper).to receive(:value).with(:fr, "foo") { "<script>one two</script>" }
       allow(i18n_wrapper).to receive(:value).with(:fr, "bar") { "one two" }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "baz") { "<script>one two</div>" }
     end
 
     it "returns keys that include script tags" do
-      expect(collection.to_a).to eq(["en: bar", "fr: foo"])
+      expect(collection.to_a).to eq(["en: bar", "fr: foo", "fr: baz"])
     end
   end
 end

--- a/spec/lib/i18n/hygiene/keys_with_script_tags_spec.rb
+++ b/spec/lib/i18n/hygiene/keys_with_script_tags_spec.rb
@@ -12,7 +12,7 @@ describe I18n::Hygiene::KeysWithScriptTags do
       allow(i18n_wrapper).to receive(:value).with(:en, "foo") { "one two" }
       allow(i18n_wrapper).to receive(:value).with(:en, "bar") { "<script>one two</script>" }
       allow(i18n_wrapper).to receive(:value).with(:en, "baz") { "one two" }
-      allow(i18n_wrapper).to receive(:value).with(:fr, "foo") { "<script>one two</script>" }
+      allow(i18n_wrapper).to receive(:value).with(:fr, "foo") { "<script src=\"https://js.stripe.com/v2/\"></script>" }
       allow(i18n_wrapper).to receive(:value).with(:fr, "bar") { "one two" }
       allow(i18n_wrapper).to receive(:value).with(:fr, "baz") { "<script>one two</div>" }
     end


### PR DESCRIPTION
The regex in `I18n::Hygiene::KeysWithScriptTags` needs to allow for malformed closing tags such as `</div>`.