### PR TITLE
Improve terminal output

### DIFF
--- a/lib/i18n/hygiene/checks/html_entity.rb
+++ b/lib/i18n/hygiene/checks/html_entity.rb
@@ -13,9 +13,10 @@ module I18n
 
           keys_with_entities = I18n::Hygiene::KeysWithEntities.new(i18nwrapper: wrapper)
 
-          keys_with_entities.each do |key|
+          keys_with_entities.each do |locale, key|
             message = ErrorMessageBuilder.new
               .title("Unexpected HTML entity")
+              .locale(locale)
               .key(key)
               .create
 

--- a/lib/i18n/hygiene/checks/html_entity.rb
+++ b/lib/i18n/hygiene/checks/html_entity.rb
@@ -18,6 +18,7 @@ module I18n
               .title("Unexpected HTML entity")
               .locale(locale)
               .key(key)
+              .translation(wrapper.value(locale, key))
               .create
 
             yield Result.new(:failure, message: message)

--- a/lib/i18n/hygiene/checks/html_entity.rb
+++ b/lib/i18n/hygiene/checks/html_entity.rb
@@ -2,6 +2,7 @@ require 'i18n/hygiene/checks/base'
 require 'i18n/hygiene/keys_with_entities'
 require 'i18n/hygiene/result'
 require 'i18n/hygiene/wrapper'
+require 'i18n/hygiene/error_message_builder'
 
 module I18n
   module Hygiene
@@ -13,7 +14,12 @@ module I18n
           keys_with_entities = I18n::Hygiene::KeysWithEntities.new(i18nwrapper: wrapper)
 
           keys_with_entities.each do |key|
-            yield Result.new(:failure, message: "\n#{key} has unexpected html entity.\n")
+            message = ErrorMessageBuilder.new
+              .title("Unexpected HTML entity")
+              .key(key)
+              .create
+
+            yield Result.new(:failure, message: message)
           end
         end
 

--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -18,7 +18,7 @@ module I18n
               yield Result.new(:pass, message: ".")
             else
               message = ErrorMessageBuilder.new
-                .title("Unused Translation")
+                .title("Unused translation")
                 .key(key)
                 .create
 

--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -3,6 +3,7 @@ require 'i18n/hygiene/wrapper'
 require 'i18n/hygiene/checks/base'
 require 'i18n/hygiene/key_usage_checker'
 require 'i18n/hygiene/result'
+require 'i18n/hygiene/error_message_builder'
 
 module I18n
   module Hygiene
@@ -16,7 +17,12 @@ module I18n
             if key_usage_checker.used?(key)
               yield Result.new(:pass, message: ".")
             else
-              yield Result.new(:failure, message: "\n#{key} is unused.\n")
+              message = ErrorMessageBuilder.new
+                .title("Unused Translation")
+                .key(key)
+                .create
+
+              yield Result.new(:failure, message: message)
             end
           end
         end

--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -25,8 +25,6 @@ module I18n
                   .create
 
                 yield Result.new(:failure, message: message)
-              else
-                yield Result.new(:pass, message: ".")
               end
             end
           end

--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -17,7 +17,7 @@ module I18n
             checker.mismatched_variables do |locale, key, missing_variables|
               if missing_variables.any?
                 message = ErrorMessageBuilder.new
-                  .title("Missing Interpolation Variable(s)")
+                  .title("Missing interpolation variable(s)")
                   .locale(locale)
                   .key(key)
                   .expected(missing_variables.join(", "))

--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -2,6 +2,7 @@ require 'i18n/hygiene/wrapper'
 require 'i18n/hygiene/checks/base'
 require 'i18n/hygiene/variable_checker'
 require 'i18n/hygiene/result'
+require 'i18n/hygiene/error_message_builder'
 
 module I18n
   module Hygiene
@@ -15,18 +16,19 @@ module I18n
 
             checker.mismatched_variables do |locale, key, missing_variables|
               if missing_variables.any?
-                yield Result.new(:failure, message: failure_message(locale, key, missing_variables))
+                message = ErrorMessageBuilder.new
+                  .title("Missing Interpolation Variable(s)")
+                  .locale(locale)
+                  .key(key)
+                  .expected(missing_variables.join(", "))
+                  .create
+
+                yield Result.new(:failure, message: message)
               else
                 yield Result.new(:pass, message: ".")
               end
             end
           end
-        end
-
-        private
-
-        def failure_message(locale, key, missing_variables)
-          "\n#{key} for locale #{locale} is missing interpolation variable(s): #{missing_variables.join(", ")}\n"
         end
       end
     end

--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -20,6 +20,7 @@ module I18n
                   .title("Missing interpolation variable(s)")
                   .locale(locale)
                   .key(key)
+                  .translation(wrapper.value(locale, key))
                   .expected(missing_variables.join(", "))
                   .create
 

--- a/lib/i18n/hygiene/checks/script_tag.rb
+++ b/lib/i18n/hygiene/checks/script_tag.rb
@@ -18,6 +18,7 @@ module I18n
               .title("Unexpected script tag")
               .locale(locale)
               .key(key)
+              .translation(wrapper.value(locale, key))
               .create
 
             yield Result.new(:failure, message: message)

--- a/lib/i18n/hygiene/checks/script_tag.rb
+++ b/lib/i18n/hygiene/checks/script_tag.rb
@@ -2,6 +2,7 @@ require 'i18n/hygiene/checks/base'
 require 'i18n/hygiene/keys_with_script_tags'
 require 'i18n/hygiene/result'
 require 'i18n/hygiene/wrapper'
+require 'i18n/hygiene/error_message_builder'
 
 module I18n
   module Hygiene
@@ -13,7 +14,12 @@ module I18n
           keys_with_script_tags = I18n::Hygiene::KeysWithScriptTags.new(i18n_wrapper: wrapper)
 
           keys_with_script_tags.each do |key|
-            yield Result.new(:failure, message: "\n#{key} has unexpected script tag.\n")
+            message = ErrorMessageBuilder.new
+              .title("Unexpected Script Tag")
+              .key(key)
+              .create
+
+            yield Result.new(:failure, message: message)
           end
         end
 

--- a/lib/i18n/hygiene/checks/script_tag.rb
+++ b/lib/i18n/hygiene/checks/script_tag.rb
@@ -13,9 +13,10 @@ module I18n
 
           keys_with_script_tags = I18n::Hygiene::KeysWithScriptTags.new(i18n_wrapper: wrapper)
 
-          keys_with_script_tags.each do |key|
+          keys_with_script_tags.each do |locale, key|
             message = ErrorMessageBuilder.new
               .title("Unexpected script tag")
+              .locale(locale)
               .key(key)
               .create
 

--- a/lib/i18n/hygiene/checks/script_tag.rb
+++ b/lib/i18n/hygiene/checks/script_tag.rb
@@ -15,7 +15,7 @@ module I18n
 
           keys_with_script_tags.each do |key|
             message = ErrorMessageBuilder.new
-              .title("Unexpected Script Tag")
+              .title("Unexpected script tag")
               .key(key)
               .create
 

--- a/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
+++ b/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
@@ -10,9 +10,10 @@ module I18n
         def run
           keys_with_return_symbols = I18n::Hygiene::KeysWithReturnSymbol.new
 
-          keys_with_return_symbols.each do |key|
+          keys_with_return_symbols.each do |locale, key|
             message = ErrorMessageBuilder.new
               .title("Unexpected return symbol (U+23CE)")
+              .locale(locale)
               .key(key)
               .create
 

--- a/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
+++ b/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
@@ -1,6 +1,7 @@
 require 'i18n/hygiene/checks/base'
 require 'i18n/hygiene/keys_with_return_symbol'
 require 'i18n/hygiene/result'
+require 'i18n/hygiene/error_message_builder'
 
 module I18n
   module Hygiene
@@ -10,7 +11,12 @@ module I18n
           keys_with_return_symbols = I18n::Hygiene::KeysWithReturnSymbol.new
 
           keys_with_return_symbols.each do |key|
-            yield Result.new(:failure, message: "\n#{key} has unexpected return symbol (U+23CE).\n")
+            message = ErrorMessageBuilder.new
+              .title("Unexpected return symbol (U+23CE)")
+              .key(key)
+              .create
+
+            yield Result.new(:failure, message: message)
           end
         end
 

--- a/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
+++ b/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
@@ -8,13 +8,15 @@ module I18n
     module Checks
       class UnexpectedReturnSymbol < Base
         def run
-          keys_with_return_symbols = I18n::Hygiene::KeysWithReturnSymbol.new
+          wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales)
+          keys_with_return_symbols = I18n::Hygiene::KeysWithReturnSymbol.new(i18n_wrapper: wrapper)
 
           keys_with_return_symbols.each do |locale, key|
             message = ErrorMessageBuilder.new
               .title("Unexpected return symbol (U+23CE)")
               .locale(locale)
               .key(key)
+              .translation(wrapper.value(locale, key))
               .create
 
             yield Result.new(:failure, message: message)

--- a/lib/i18n/hygiene/error_message_builder.rb
+++ b/lib/i18n/hygiene/error_message_builder.rb
@@ -1,0 +1,81 @@
+require 'rainbow'
+
+module  I18n
+  module Hygiene
+    class ErrorMessageBuilder
+      LEFT_PAD = " " * 2
+      TRUNCATE_LIMIT = 48
+
+      def initialize
+        @title = "Unspecified Error"
+        @key = "unknown_key"
+        @locale = nil
+        @translation = nil
+        @location = nil
+      end
+
+      def title(title)
+        @title = title
+        self
+      end
+
+      def locale(locale)
+        @locale = locale
+        self
+      end
+
+      def key(key)
+        @key = key
+        self
+      end
+
+      def translation(translation)
+        @translation = translation
+        self
+      end
+
+      def location(location)
+        @location = location
+        self
+      end
+
+      def create
+        s = StringIO.new
+        s << "\n"
+        s << Rainbow("i18n-hygiene/#{@title}:").red
+        s << "\n"
+        s << LEFT_PAD
+
+        if @locale
+          s << "#{@locale}."
+        end
+
+        s << @key
+
+        if @translation
+          s << ": "
+          s << Rainbow("\"#{truncated_translation}\"").yellow
+        end
+
+        if @location
+          s << "\n"
+          s << LEFT_PAD
+          s << Rainbow(@location).cyan
+        end
+
+        s << "\n"
+        s.string
+      end
+
+      private
+
+      def truncated_translation
+        if @translation.length > TRUNCATE_LIMIT
+          @translation[0..TRUNCATE_LIMIT] + "..."
+        else
+          @translation
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/hygiene/error_message_builder.rb
+++ b/lib/i18n/hygiene/error_message_builder.rb
@@ -29,6 +29,11 @@ module  I18n
         self
       end
 
+      def expected(expected)
+        @expected = expected
+        self
+      end
+
       def translation(translation)
         @translation = translation
         self
@@ -55,6 +60,13 @@ module  I18n
         if @translation
           s << ": "
           s << Rainbow("\"#{truncated_translation}\"").yellow
+        end
+
+        if @expected
+          s << "\n"
+          s << LEFT_PAD * 2
+          s << "Expected: "
+          s << Rainbow(@expected).color(:orange)
         end
 
         if @location

--- a/lib/i18n/hygiene/error_message_builder.rb
+++ b/lib/i18n/hygiene/error_message_builder.rb
@@ -39,11 +39,6 @@ module  I18n
         self
       end
 
-      def location(location)
-        @location = location
-        self
-      end
-
       def create
         s = StringIO.new
         s << "\n"
@@ -67,12 +62,6 @@ module  I18n
           s << LEFT_PAD * 2
           s << "Expected: "
           s << Rainbow(@expected).color(:orange)
-        end
-
-        if @location
-          s << "\n"
-          s << LEFT_PAD
-          s << Rainbow(@location).cyan
         end
 
         s << "\n"

--- a/lib/i18n/hygiene/keys_with_matched_value.rb
+++ b/lib/i18n/hygiene/keys_with_matched_value.rb
@@ -8,20 +8,17 @@ module I18n
         @regex = regex
         @i18n = i18n_wrapper || I18n::Hygiene::Wrapper.new(keys_to_skip: [])
         @reject_keys = reject_keys
-        @matching_keys = load_matching_keys
       end
 
       def each(&block)
-        @matching_keys.each(&block)
+        locales.each do |locale|
+          matching_keys(locale).each do |key|
+            block.call(locale, key)
+          end
+        end
       end
 
       private
-
-      def load_matching_keys
-        locales.inject([]) do |results, locale|
-          results + matching_keys(locale).map { |key| "#{locale}: #{key}" }
-        end
-      end
 
       def matching_keys(locale)
         keys_to_check(locale).select { |key| i18n.value(locale, key).to_s.match(regex) }

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -29,20 +29,20 @@ RSpec.describe "i18n-hygiene" do
             translation.dynamic
           ....
           i18n-hygiene/Missing interpolation variable(s):
-            fr_invalid.translation.interpolation
+            fr_invalid.translation.interpolation: "dont need no interpolation!"
               Expected: qux
           ..
           i18n-hygiene/Unexpected HTML entity:
-            en_invalid.translation.dynamic
+            en_invalid.translation.dynamic: "foo &quot;"
 
           i18n-hygiene/Unexpected HTML entity:
-            fr_invalid.translation.full_key
+            fr_invalid.translation.full_key: "baz ⏎ &amp;"
 
           i18n-hygiene/Unexpected script tag:
-            en_invalid.translation.plural.one
+            en_invalid.translation.plural.one: "<script>bar</script>"
 
           i18n-hygiene/Unexpected return symbol (U+23CE):
-            fr_invalid.translation.full_key
+            fr_invalid.translation.full_key: "baz ⏎ &amp;"
 
           i18n hygiene checks failed.
         MESSAGE

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe "i18n-hygiene" do
           system("#{shell_cmd} 2> /dev/null")
         }.to output(<<~MESSAGE).to_stdout_from_any_process
 
-          translation.dynamic is unused.
+          i18n-hygiene/Unused Translation:
+            translation.dynamic
           ....
           translation.interpolation for locale fr_invalid is missing interpolation variable(s): qux
           ..

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe "i18n-hygiene" do
           i18n-hygiene/Unused Translation:
             translation.dynamic
           ....
-          translation.interpolation for locale fr_invalid is missing interpolation variable(s): qux
+          i18n-hygiene/Missing Interpolation Variable(s):
+            fr_invalid.translation.interpolation
+              Expected: qux
           ..
           i18n-hygiene/Unexpected HTML entity:
             en_invalid: translation.dynamic

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -33,16 +33,16 @@ RSpec.describe "i18n-hygiene" do
               Expected: qux
           ..
           i18n-hygiene/Unexpected HTML entity:
-            en_invalid: translation.dynamic
+            en_invalid.translation.dynamic
 
           i18n-hygiene/Unexpected HTML entity:
-            fr_invalid: translation.full_key
+            fr_invalid.translation.full_key
 
           i18n-hygiene/Unexpected script tag:
-            en_invalid: translation.plural.one
+            en_invalid.translation.plural.one
 
           i18n-hygiene/Unexpected return symbol (U+23CE):
-            fr_invalid: translation.full_key
+            fr_invalid.translation.full_key
 
           i18n hygiene checks failed.
         MESSAGE

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe "i18n-hygiene" do
 
           i18n-hygiene/Unused translation:
             translation.dynamic
-          ....
+          ...
           i18n-hygiene/Missing interpolation variable(s):
             fr_invalid.translation.interpolation: "dont need no interpolation!"
               Expected: qux
-          ..
+
           i18n-hygiene/Unexpected HTML entity:
             en_invalid.translation.dynamic: "foo &quot;"
 

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -25,10 +25,10 @@ RSpec.describe "i18n-hygiene" do
           system("#{shell_cmd} 2> /dev/null")
         }.to output(<<~MESSAGE).to_stdout_from_any_process
 
-          i18n-hygiene/Unused Translation:
+          i18n-hygiene/Unused translation:
             translation.dynamic
           ....
-          i18n-hygiene/Missing Interpolation Variable(s):
+          i18n-hygiene/Missing interpolation variable(s):
             fr_invalid.translation.interpolation
               Expected: qux
           ..
@@ -38,7 +38,7 @@ RSpec.describe "i18n-hygiene" do
           i18n-hygiene/Unexpected HTML entity:
             fr_invalid: translation.full_key
 
-          i18n-hygiene/Unexpected Script Tag:
+          i18n-hygiene/Unexpected script tag:
             en_invalid: translation.plural.one
 
           i18n-hygiene/Unexpected return symbol (U+23CE):

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe "i18n-hygiene" do
           i18n-hygiene/Unexpected HTML entity:
             fr_invalid: translation.full_key
 
-          en_invalid: translation.plural.one has unexpected script tag.
+          i18n-hygiene/Unexpected Script Tag:
+            en_invalid: translation.plural.one
 
           fr_invalid: translation.full_key has unexpected return symbol (U+23CE).
 

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -30,9 +30,11 @@ RSpec.describe "i18n-hygiene" do
           ....
           translation.interpolation for locale fr_invalid is missing interpolation variable(s): qux
           ..
-          en_invalid: translation.dynamic has unexpected html entity.
+          i18n-hygiene/Unexpected HTML entity:
+            en_invalid: translation.dynamic
 
-          fr_invalid: translation.full_key has unexpected html entity.
+          i18n-hygiene/Unexpected HTML entity:
+            fr_invalid: translation.full_key
 
           en_invalid: translation.plural.one has unexpected script tag.
 

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -41,7 +41,8 @@ RSpec.describe "i18n-hygiene" do
           i18n-hygiene/Unexpected Script Tag:
             en_invalid: translation.plural.one
 
-          fr_invalid: translation.full_key has unexpected return symbol (U+23CE).
+          i18n-hygiene/Unexpected return symbol (U+23CE):
+            fr_invalid: translation.full_key
 
           i18n hygiene checks failed.
         MESSAGE

--- a/spec/lib/i18n/hygiene/error_message_builder_spec.rb
+++ b/spec/lib/i18n/hygiene/error_message_builder_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe I18n::Hygiene::ErrorMessageBuilder do
           .locale("ja")
           .key("ketchup")
           .translation("ケチャップ")
+          .expected("lots of ketchup use!")
           .location("./config/locales/ja.yml:765")
       end
 
@@ -29,6 +30,7 @@ RSpec.describe I18n::Hygiene::ErrorMessageBuilder do
 
           \e[31mi18n-hygiene/Condiment Missing:\e[0m
             ja.ketchup: \e[33m\"ケチャップ"\e[0m
+              Expected: \e[38;5;214mlots of ketchup use!\e[0m
             \e[36m./config/locales/ja.yml:765\e[0m
         STRING
       end

--- a/spec/lib/i18n/hygiene/error_message_builder_spec.rb
+++ b/spec/lib/i18n/hygiene/error_message_builder_spec.rb
@@ -1,0 +1,37 @@
+require "i18n/hygiene/error_message_builder"
+
+RSpec.describe I18n::Hygiene::ErrorMessageBuilder do
+  let(:builder) { I18n::Hygiene::ErrorMessageBuilder.new }
+
+  describe "#create" do
+    context "defaults" do
+      it "builds a colourised string" do
+        expect(builder.create).to eq <<~STRING
+
+          \e[31mi18n-hygiene/Unspecified Error:\e[0m
+            unknown_key
+        STRING
+      end
+    end
+
+    context "setting all the things" do
+      before do
+        builder
+          .title("Condiment Missing")
+          .locale("ja")
+          .key("ketchup")
+          .translation("ケチャップ")
+          .location("./config/locales/ja.yml:765")
+      end
+
+      it "builds a colourised string" do
+        expect(builder.create).to eq <<~STRING
+
+          \e[31mi18n-hygiene/Condiment Missing:\e[0m
+            ja.ketchup: \e[33m\"ケチャップ"\e[0m
+            \e[36m./config/locales/ja.yml:765\e[0m
+        STRING
+      end
+    end
+  end
+end

--- a/spec/lib/i18n/hygiene/error_message_builder_spec.rb
+++ b/spec/lib/i18n/hygiene/error_message_builder_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe I18n::Hygiene::ErrorMessageBuilder do
           .key("ketchup")
           .translation("ケチャップ")
           .expected("lots of ketchup use!")
-          .location("./config/locales/ja.yml:765")
       end
 
       it "builds a colourised string" do
@@ -31,7 +30,6 @@ RSpec.describe I18n::Hygiene::ErrorMessageBuilder do
           \e[31mi18n-hygiene/Condiment Missing:\e[0m
             ja.ketchup: \e[33m\"ケチャップ"\e[0m
               Expected: \e[38;5;214mlots of ketchup use!\e[0m
-            \e[36m./config/locales/ja.yml:765\e[0m
         STRING
       end
     end

--- a/spec/lib/i18n/hygiene/keys_with_entities_spec.rb
+++ b/spec/lib/i18n/hygiene/keys_with_entities_spec.rb
@@ -21,7 +21,7 @@ describe I18n::Hygiene::KeysWithEntities do
       end
 
       it "returns the appropriate result" do
-        expect(collection.to_a).to eq ["en: bar", "fr: foo"]
+        expect(collection.to_a).to eq [[:en, "bar"], [:fr, "foo"]]
       end
     end
   end

--- a/spec/lib/i18n/hygiene/keys_with_return_symbol_spec.rb
+++ b/spec/lib/i18n/hygiene/keys_with_return_symbol_spec.rb
@@ -16,7 +16,7 @@ describe I18n::Hygiene::KeysWithReturnSymbol do
     end
 
     it "returns keys that include return symbol" do
-      expect(collection.to_a).to eq ["en: bar", "fr: foo"]
+      expect(collection.to_a).to eq [[:en, "bar"], [:fr, "foo"]]
     end
   end
 end

--- a/spec/lib/i18n/hygiene/keys_with_script_tags_spec.rb
+++ b/spec/lib/i18n/hygiene/keys_with_script_tags_spec.rb
@@ -18,7 +18,7 @@ describe I18n::Hygiene::KeysWithScriptTags do
     end
 
     it "returns keys that include script tags" do
-      expect(collection.to_a).to eq(["en: bar", "fr: foo", "fr: baz"])
+      expect(collection.to_a).to eq([[:en, "bar"], [:fr, "foo"], [:fr, "baz"]])
     end
   end
 end


### PR DESCRIPTION
This is the final PR in the series (for now!)

This unifies all output from each of the checks by using a new `ErrorMessageBuilder` in every case we want to report on a check that fails.

I had to mess with `KeysWithMatchedValue` a little so I could get the locale in a consistent way, but the changes are pretty innocuous.

Before
![screenshot at 2017-07-18 18-49-08](https://user-images.githubusercontent.com/2295892/28308536-d3c4877e-6be9-11e7-8736-abb42aaac0eb.png)


After
![screenshot at 2017-07-18 19-02-29](https://user-images.githubusercontent.com/2295892/28309113-ae71356a-6beb-11e7-9c83-7410741950ec.png)

