### PR TITLE
Update gem summary and description to help potential users

### DIFF
--- a/i18n-hygiene.gemspec
+++ b/i18n-hygiene.gemspec
@@ -2,8 +2,8 @@ Gem::Specification.new do |s|
   s.name        = 'i18n-hygiene'
   s.version     = '0.1.0'
   s.license     = 'MIT'
-  s.summary     = "Helps maintain translations."
-  s.description = "Provides rake tasks to help maintain translations."
+  s.summary     = "A linter for translation data in ruby applications"
+  s.description = "Provides a rake task that checks locale data for likely issues. Intended to be used in build pipelines to detect problems before they reach production"
   s.authors     = [ "Nick Browne"," Keith Pitty" ]
   s.email       = "dev@theconversation.edu.au"
   s.files       = `git ls-files -- lib/*`.split("\n")


### PR DESCRIPTION
I lost the discussion about changing the gem name, but I think it's worth expanding the summary and description to provide more detail.

In particular, I wanted to include "linter" as a short cut to communicating the type of tool this is.