### PR TITLE
Git grep instead of ag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: ruby
 rvm:
   - 2.4.1
-dist: trusty
-sudo: required
-before_install:
-  - sudo apt-get install silversearcher-ag
 notifications:
   slack:
     secure: hlY8BrMzhqWRd8urCScKtdOVJPMdV8I8e65KeYVEvUTX7rtbxRjOGc55QNa7b8EpBetsGWYHKfuHIzDtAS/BUKKeO21mr/N/j9O4/9XDVLBltAucnhDjDiunXeQMs2COBBn6+K6dlKf82HUs320fV+cyLYJT2ekz3y3jONDTfrP3WBNjoXbIR86uDSq2ktrMZ9MOxCtvSc7CAPFYtn+p5jnsTJGMp0T1extW8GSXM00rDEaPXVmV8O0H63SG6yO/z1ZmquPHZBzgZmbMrnuW82hWGMny1JrCId5YTsLfzERw+YuRxU7WN7k727n1XWcGU6M4cRM9EV+f6G/Ygom7+9feZYU8+CsAiI0BagmwPOi0bVLgzstvI9gNwdrE4T9G/2V+HeYWsJvXexKl9ewUubLrxqYseHJcyhszZ4MbP6DVhbm6jy50EDie5cThpFgEPri6NW3G+WxdnBWNinxF/gw4Q2y2+a6Pw5h9OXvqJ0VHYyE0udlgoMIAE/dR5qkz7BmjYx39EVhX7gsI+Tx1CHIbdfWj8NaXoQLDDQoJ8GnbR2NXwSI9SyVwZu7AMZfaIa88rQH+uKsgU5lTqhy4nh213b492AdbQNTuxk0tstskbZfrKNnB4uBRAS0fcj3T/+kk6mkb5AwUPwrJUIP7Twrk4fD5I9SxUe1gIuiGFlA=

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -5,7 +5,6 @@ module I18n
 
       def initialize(directories:)
         @directories = directories
-        @tool = ag_or_ack
       end
 
       def used?(key)
@@ -18,17 +17,7 @@ module I18n
         if pluralized_key_used?(key)
           fully_qualified_key_used?(without_last_part(key))
         else
-          %x<#{@tool} #{key} #{@directories.join(" ")} | wc -l>.strip.to_i > 0
-        end
-      end
-
-      def ag_or_ack
-        if system("which ag > /dev/null")
-          return "ag"
-        elsif system("which ack > /dev/null")
-          return "ack --type-add=js=.coffee"
-        else
-          raise "Must have either ag (silversearcher-ag) or ack installed."
+          %x<git grep #{key} #{@directories.join(" ")} | wc -l>.strip.to_i > 0
         end
       end
 

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -5,6 +5,8 @@ module I18n
 
       def initialize(directories:)
         @directories = directories
+
+        raise "Must have git installed!" unless system("which git > /dev/null")
       end
 
       def used?(key)

--- a/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
@@ -16,10 +16,9 @@ describe I18n::Hygiene::KeyUsageChecker do
     end
 
     context "shelling out" do
-      # stub system calls to ack/ag and wc
+      # stub system calls to git grep and wc
       before do
-        allow(checker_instance).to receive(:ag_or_ack).and_return("ag")
-        expect(checker_instance).to receive(:`).with("ag my.key you only yolo once | wc -l").and_return(wc_result)
+        expect(checker_instance).to receive(:`).with("git grep my.key you only yolo once | wc -l").and_return(wc_result)
       end
 
       context "wc is zero" do


### PR DESCRIPTION
While investigating what we can do about the ignored keys unintended behaviour, I discovered (thanks to https://github.com/ggreer/the_silver_searcher readme) that we can use `git grep` instead of `ag` and it's just as fast.

Added bonus of being able to grep only particular file extensions, which leads to some optimisations (yet to come).