### PR TITLE
Swap fail for exit(1)

### DIFF
--- a/lib/i18n/hygiene/rake_task.rb
+++ b/lib/i18n/hygiene/rake_task.rb
@@ -41,7 +41,7 @@ module I18n
 
           reporter.report
 
-          fail unless reporter.passed?
+          exit(1) unless reporter.passed?
         end
       end
 


### PR DESCRIPTION
Instead of using `fail` can we use `exit(1)` here.

Using fail is raising an exception which adds confusion.

Using `exit(1)` will still return a failing status code, and thus should fail CI.