### PR TITLE
Sensible defaults

### DIFF
--- a/lib/i18n/hygiene/checks/base.rb
+++ b/lib/i18n/hygiene/checks/base.rb
@@ -11,10 +11,14 @@ module I18n
           raise "#run must be implemented by subclass"
         end
 
-        private
+        protected
 
         def config
           @config
+        end
+
+        def all_locales
+          config.all_locales
         end
       end
     end

--- a/lib/i18n/hygiene/checks/html_entity.rb
+++ b/lib/i18n/hygiene/checks/html_entity.rb
@@ -24,12 +24,6 @@ module I18n
             yield Result.new(:failure, message: message)
           end
         end
-
-        private
-
-        def all_locales
-          [config.primary_locale] + config.locales
-        end
       end
     end
   end

--- a/lib/i18n/hygiene/checks/script_tag.rb
+++ b/lib/i18n/hygiene/checks/script_tag.rb
@@ -24,12 +24,6 @@ module I18n
             yield Result.new(:failure, message: message)
           end
         end
-
-        private
-
-        def all_locales
-          [config.primary_locale] + config.locales
-        end
       end
     end
   end

--- a/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
+++ b/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
@@ -22,13 +22,6 @@ module I18n
             yield Result.new(:failure, message: message)
           end
         end
-
-        private
-
-        def all_locales
-          [config.primary_locale] + config.locales
-        end
-
       end
     end
   end

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -18,7 +18,7 @@ module I18n
       end
 
       def locales
-        @locales ||= []
+        @locales ||= ::I18n.available_locales
       end
 
       def keys_to_skip

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -8,7 +8,6 @@ module I18n
       attr_writer :locales
       attr_writer :keys_to_skip
       attr_writer :concurrency
-      attr_reader :all_locales
 
       def directories
         @directories ||= []

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -8,6 +8,7 @@ module I18n
       attr_writer :locales
       attr_writer :keys_to_skip
       attr_writer :concurrency
+      attr_reader :all_locales
 
       def directories
         @directories ||= []
@@ -19,6 +20,10 @@ module I18n
 
       def locales
         @locales ||= ::I18n.available_locales
+      end
+
+      def all_locales
+        [primary_locale] + locales
       end
 
       def keys_to_skip


### PR DESCRIPTION
This PR introduces the use of the `available_locales` from the global `I18n` object as a default for the configurable locales. It also takes the opportunity to refactor the derivation of `all_locales` that is used in several checks.