### PR TITLE
Unify unexpected checks

### DIFF
--- a/lib/i18n/hygiene/checks/html_entity.rb
+++ b/lib/i18n/hygiene/checks/html_entity.rb
@@ -1,28 +1,19 @@
-require 'i18n/hygiene/checks/base'
+require 'i18n/hygiene/checks/unexpected_regex_match'
 require 'i18n/hygiene/keys_with_entities'
-require 'i18n/hygiene/result'
-require 'i18n/hygiene/wrapper'
-require 'i18n/hygiene/error_message_builder'
 
 module I18n
   module Hygiene
     module Checks
-      class HtmlEntity < Base
-        def run
-          wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales)
+      class HtmlEntity < UnexpectedRegexMatch
 
-          keys_with_entities = I18n::Hygiene::KeysWithEntities.new(i18nwrapper: wrapper)
+        protected
 
-          keys_with_entities.each do |locale, key|
-            message = ErrorMessageBuilder.new
-              .title("Unexpected HTML entity")
-              .locale(locale)
-              .key(key)
-              .translation(wrapper.value(locale, key))
-              .create
+        def keys
+          I18n::Hygiene::KeysWithEntities.new(i18nwrapper: wrapper)
+        end
 
-            yield Result.new(:failure, message: message)
-          end
+        def title
+          "Unexpected HTML entity"
         end
       end
     end

--- a/lib/i18n/hygiene/checks/script_tag.rb
+++ b/lib/i18n/hygiene/checks/script_tag.rb
@@ -1,28 +1,19 @@
-require 'i18n/hygiene/checks/base'
+require 'i18n/hygiene/checks/unexpected_regex_match'
 require 'i18n/hygiene/keys_with_script_tags'
-require 'i18n/hygiene/result'
-require 'i18n/hygiene/wrapper'
-require 'i18n/hygiene/error_message_builder'
 
 module I18n
   module Hygiene
     module Checks
-      class ScriptTag < Base
-        def run
-          wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales)
+      class ScriptTag < UnexpectedRegexMatch
 
-          keys_with_script_tags = I18n::Hygiene::KeysWithScriptTags.new(i18n_wrapper: wrapper)
+        protected
 
-          keys_with_script_tags.each do |locale, key|
-            message = ErrorMessageBuilder.new
-              .title("Unexpected script tag")
-              .locale(locale)
-              .key(key)
-              .translation(wrapper.value(locale, key))
-              .create
+        def keys
+          I18n::Hygiene::KeysWithScriptTags.new(i18n_wrapper: wrapper)
+        end
 
-            yield Result.new(:failure, message: message)
-          end
+        def title
+          "Unexpected script tag"
         end
       end
     end

--- a/lib/i18n/hygiene/checks/unexpected_regex_match.rb
+++ b/lib/i18n/hygiene/checks/unexpected_regex_match.rb
@@ -1,0 +1,38 @@
+require 'i18n/hygiene/checks/base'
+require 'i18n/hygiene/result'
+require 'i18n/hygiene/error_message_builder'
+
+module I18n
+  module Hygiene
+    module Checks
+      class UnexpectedRegexMatch < Base
+        def run
+          keys.each do |locale, key|
+            message = ErrorMessageBuilder.new
+              .title(title)
+              .locale(locale)
+              .key(key)
+              .translation(wrapper.value(locale, key))
+              .create
+
+            yield Result.new(:failure, message: message)
+          end
+        end
+          
+        protected
+
+        def wrapper
+          I18n::Hygiene::Wrapper.new(locales: all_locales)
+        end
+
+        def keys
+          raise "#keys must be implemented by subclass"
+        end
+
+        def title
+          raise "#title must be implemented by subclass"
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
+++ b/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
@@ -1,26 +1,19 @@
-require 'i18n/hygiene/checks/base'
+require 'i18n/hygiene/checks/unexpected_regex_match'
 require 'i18n/hygiene/keys_with_return_symbol'
-require 'i18n/hygiene/result'
-require 'i18n/hygiene/error_message_builder'
 
 module I18n
   module Hygiene
     module Checks
-      class UnexpectedReturnSymbol < Base
-        def run
-          wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales)
-          keys_with_return_symbols = I18n::Hygiene::KeysWithReturnSymbol.new(i18n_wrapper: wrapper)
+      class UnexpectedReturnSymbol < UnexpectedRegexMatch
 
-          keys_with_return_symbols.each do |locale, key|
-            message = ErrorMessageBuilder.new
-              .title("Unexpected return symbol (U+23CE)")
-              .locale(locale)
-              .key(key)
-              .translation(wrapper.value(locale, key))
-              .create
+        protected
 
-            yield Result.new(:failure, message: message)
-          end
+        def keys
+          I18n::Hygiene::KeysWithReturnSymbol.new(i18n_wrapper: wrapper)
+        end
+
+        def title
+          "Unexpected return symbol (U+23CE)"
         end
       end
     end


### PR DESCRIPTION
This PR introduces a class called `UnexpectedRegexMatch` to hold the code that is common to checks for unexpected regex matches. We have three such checks: `HtmlEntity`, `ScriptTag` and `UnexpectedReturnSymbol`. These have been changed to inherit from `UnexpectedRegexMatch`.

I know that inheritance is frowned upon but think that it is appropriate in this case. I attempted to use composition but found that approach to be unworkable because we expect our checks to yield an instance of `Result` to be concatenated into the reporter in the Rake task.