### PR TITLE
Optionally limit files and file extensions

### DIFF
--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -13,6 +13,7 @@ module I18n
           key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(
             directories: config.directories,
             exclude_files: config.exclude_files,
+            file_extensions: config.file_extensions
           )
 
           wrapper = I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip)

--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -10,7 +10,11 @@ module I18n
     module Checks
       class KeyUsage < Base
         def run
-          key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(directories: config.directories)
+          key_usage_checker = I18n::Hygiene::KeyUsageChecker.new(
+            directories: config.directories,
+            exclude_files: config.exclude_files,
+          )
+
           wrapper = I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip)
 
           Parallel.each(wrapper.keys_to_check(config.primary_locale), in_threads: config.concurrency) do |key|

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -3,11 +3,16 @@ require 'parallel'
 module I18n
   module Hygiene
     class Config
+      attr_writer :exclude_files
       attr_writer :directories
       attr_writer :primary_locale
       attr_writer :locales
       attr_writer :keys_to_skip
       attr_writer :concurrency
+
+      def exclude_files
+        @exclude_files ||= []
+      end
 
       def directories
         @directories ||= []

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -5,6 +5,7 @@ module I18n
     class Config
       attr_writer :exclude_files
       attr_writer :directories
+      attr_writer :file_extensions
       attr_writer :primary_locale
       attr_writer :locales
       attr_writer :keys_to_skip
@@ -16,6 +17,10 @@ module I18n
 
       def directories
         @directories ||= []
+      end
+
+      def file_extensions
+        @file_extensions ||= ["rb", "erb", "coffee", "js", "jsx"]
       end
 
       def primary_locale

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -21,10 +21,12 @@ module I18n
         if pluralized_key_used?(key)
           fully_qualified_key_used?(without_last_part(key))
         else
-          options = [git_grep_include, git_grep_exclude].reject(&:empty?).join(" ")
-
-          %x<git grep #{key} #{options} | wc -l>.strip.to_i > 0
+          %x<git grep #{key} #{git_grep_options} | wc -l>.strip.to_i > 0
         end
+      end
+
+      def git_grep_options
+        [git_grep_include, git_grep_exclude].reject(&:empty?).join(" ")
       end
 
       def git_grep_include

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -3,9 +3,10 @@ module I18n
     # Checks the usage of i18n keys in the codebase.
     class KeyUsageChecker
 
-      def initialize(directories:, exclude_files: [])
+      def initialize(directories:, exclude_files: [], file_extensions: [])
         @directories = directories
         @exclude_files = exclude_files
+        @file_extensions = file_extensions
 
         raise "Must have git installed!" unless system("which git > /dev/null")
       end
@@ -20,10 +21,22 @@ module I18n
         if pluralized_key_used?(key)
           fully_qualified_key_used?(without_last_part(key))
         else
-          options = [@directories.join(" "), git_grep_exclude].reject(&:empty?).join(" ")
+          options = [git_grep_include, git_grep_exclude].reject(&:empty?).join(" ")
 
           %x<git grep #{key} #{options} | wc -l>.strip.to_i > 0
         end
+      end
+
+      def git_grep_include
+        @directories.map { |dir|
+          if @file_extensions.empty?
+            dir
+          else
+            @file_extensions.map { |ext|
+              "'#{dir}/*.#{ext}'"
+            }
+          end
+        }.flatten.join(" ")
       end
 
       def git_grep_exclude

--- a/lib/i18n/hygiene/rake_task.rb
+++ b/lib/i18n/hygiene/rake_task.rb
@@ -19,11 +19,14 @@ module I18n
         I18n::Hygiene::Checks::UnexpectedReturnSymbol,
       ]
 
-      def initialize(task_name = :hygiene)
+      def initialize(task_name = :hygiene, &block)
         config = Config.new
 
-        if block_given?
-          yield config
+        if block
+          block.call(config)
+
+          # We always want to exclude the file that is configuring this rake task
+          config.exclude_files = config.exclude_files + [relative_path_for(block.source_location)]
         end
 
         unless ::Rake.application.last_description
@@ -46,6 +49,10 @@ module I18n
       end
 
       private
+
+      def relative_path_for(source_location)
+        source_location[0].gsub("#{pwd}/", "")
+      end
 
       def reporter
         @reporter ||= Reporter.new

--- a/spec/fixtures/invalid.Rakefile
+++ b/spec/fixtures/invalid.Rakefile
@@ -9,5 +9,6 @@ I18n::Hygiene::RakeTask.new(:default) do |config|
   config.directories = ["spec/fixtures/project/app", "spec/fixtures/project/lib"]
   config.primary_locale = :en_invalid
   config.locales = [:fr_invalid]
+  config.exclude_files = ["project/app/controllers/ignored.rb"]
   config.concurrency = 1
 end

--- a/spec/fixtures/invalid.Rakefile
+++ b/spec/fixtures/invalid.Rakefile
@@ -10,5 +10,6 @@ I18n::Hygiene::RakeTask.new(:default) do |config|
   config.primary_locale = :en_invalid
   config.locales = [:fr_invalid]
   config.exclude_files = ["project/app/controllers/ignored.rb"]
+  config.file_extensions = ["rb"]
   config.concurrency = 1
 end

--- a/spec/fixtures/locales/en_invalid.yml
+++ b/spec/fixtures/locales/en_invalid.yml
@@ -1,5 +1,6 @@
 en_invalid:
   translation:
+    ignored: "ignore"
     dynamic: "foo &quot;"
     plural:
       one: "<script>bar</script>"

--- a/spec/fixtures/locales/en_invalid.yml
+++ b/spec/fixtures/locales/en_invalid.yml
@@ -1,5 +1,6 @@
 en_invalid:
   translation:
+    script: "blah"
     ignored: "ignore"
     dynamic: "foo &quot;"
     plural:

--- a/spec/fixtures/locales/en_valid.yml
+++ b/spec/fixtures/locales/en_valid.yml
@@ -1,5 +1,6 @@
 en_valid:
   translation:
+    script: "blah"
     ignored: "ignore"
     dynamic: "foo"
     plural:

--- a/spec/fixtures/locales/en_valid.yml
+++ b/spec/fixtures/locales/en_valid.yml
@@ -1,5 +1,6 @@
 en_valid:
   translation:
+    ignored: "ignore"
     dynamic: "foo"
     plural:
       one: "bar"

--- a/spec/fixtures/locales/fr_invalid.yml
+++ b/spec/fixtures/locales/fr_invalid.yml
@@ -1,5 +1,6 @@
 fr_invalid:
   translation:
+    script: "blah"
     ignored: "ignorer"
     plural:
       one: "bar"

--- a/spec/fixtures/locales/fr_invalid.yml
+++ b/spec/fixtures/locales/fr_invalid.yml
@@ -1,5 +1,6 @@
 fr_invalid:
   translation:
+    ignored: "ignorer"
     plural:
       one: "bar"
     full_key: "baz \u23ce &amp;"

--- a/spec/fixtures/locales/fr_valid.yml
+++ b/spec/fixtures/locales/fr_valid.yml
@@ -1,5 +1,6 @@
 fr_valid:
   translation:
+    ignored: "ignorer"
     dynamic: "foo"
     plural:
       one: "bar"

--- a/spec/fixtures/locales/fr_valid.yml
+++ b/spec/fixtures/locales/fr_valid.yml
@@ -1,5 +1,6 @@
 fr_valid:
   translation:
+    script: "blah"
     ignored: "ignorer"
     dynamic: "foo"
     plural:

--- a/spec/fixtures/project/app/assets/script.jsx
+++ b/spec/fixtures/project/app/assets/script.jsx
@@ -1,0 +1,1 @@
+I18next.t("translation.script");

--- a/spec/fixtures/project/app/controllers/ignored.rb
+++ b/spec/fixtures/project/app/controllers/ignored.rb
@@ -1,0 +1,5 @@
+class Ignored
+  def ignore
+    I18n.t("translation.ignored")
+  end
+end

--- a/spec/fixtures/valid.Rakefile
+++ b/spec/fixtures/valid.Rakefile
@@ -10,5 +10,6 @@ I18n::Hygiene::RakeTask.new(:default) do |config|
   config.primary_locale = :en_valid
   config.locales = [:fr_valid]
   config.keys_to_skip = "translation.dynamic"
+  config.file_extensions = ["rb", "jsx"]
   config.concurrency = 1
 end

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe "i18n-hygiene" do
 
           i18n-hygiene/Unused translation:
             translation.dynamic
+
+          i18n-hygiene/Unused translation:
+            translation.ignored
           ...
           i18n-hygiene/Missing interpolation variable(s):
             fr_invalid.translation.interpolation: "dont need no interpolation!"

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe "i18n-hygiene" do
           i18n-hygiene/Unused translation:
             translation.ignored
           ...
+          i18n-hygiene/Unused translation:
+            translation.script
+
           i18n-hygiene/Missing interpolation variable(s):
             fr_invalid.translation.interpolation: "dont need no interpolation!"
               Expected: qux

--- a/spec/lib/i18n/hygiene/checks/key_usage_spec.rb
+++ b/spec/lib/i18n/hygiene/checks/key_usage_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe I18n::Hygiene::Checks::KeyUsage do
 
     it "checks for missing interpolation variables in the configured locales" do
       expect(I18n::Hygiene::KeyUsageChecker).to receive(:new)
-        .with(directories: ["app", "lib"]).and_return key_usage_checker_double
+        .with(directories: ["app", "lib"], exclude_files: []).and_return key_usage_checker_double
 
       instance.run do |result|
         expect(result.passed?).to eq true

--- a/spec/lib/i18n/hygiene/checks/key_usage_spec.rb
+++ b/spec/lib/i18n/hygiene/checks/key_usage_spec.rb
@@ -14,7 +14,11 @@ RSpec.describe I18n::Hygiene::Checks::KeyUsage do
 
     it "checks for missing interpolation variables in the configured locales" do
       expect(I18n::Hygiene::KeyUsageChecker).to receive(:new)
-        .with(directories: ["app", "lib"], exclude_files: []).and_return key_usage_checker_double
+        .with(
+          directories: ["app", "lib"],
+          exclude_files: [],
+          file_extensions: ["rb", "erb", "coffee", "js", "jsx"]
+        ).and_return key_usage_checker_double
 
       instance.run do |result|
         expect(result.passed?).to eq true

--- a/spec/lib/i18n/hygiene/config_spec.rb
+++ b/spec/lib/i18n/hygiene/config_spec.rb
@@ -3,6 +3,13 @@ require 'i18n/hygiene/config'
 RSpec.describe I18n::Hygiene::Config do
   let(:config) { I18n::Hygiene::Config.new }
 
+  describe "#exclude_files=" do
+    it "sets exclude_files" do
+      config.exclude_files = ["ignore.this"]
+      expect(config.exclude_files).to eq ["ignore.this"]
+    end
+  end
+
   describe "#primary_locale=" do
     it "sets primary_locale" do
       config.primary_locale = :en

--- a/spec/lib/i18n/hygiene/config_spec.rb
+++ b/spec/lib/i18n/hygiene/config_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe I18n::Hygiene::Config do
     end
   end
 
+  describe "#file_extensions=" do
+    it "sets file_extensions" do
+      config.file_extensions = ["rb"]
+      expect(config.file_extensions).to eq ["rb"]
+    end
+  end
+
   describe "#primary_locale=" do
     it "sets primary_locale" do
       config.primary_locale = :en

--- a/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
@@ -16,40 +16,56 @@ describe I18n::Hygiene::KeyUsageChecker do
     end
 
     context "shelling out" do
-      # stub system calls to git grep and wc
-      before do
-        expect(checker_instance).to receive(:`).with("git grep my.key you only yolo once | wc -l").and_return(wc_result)
-      end
-
-      context "wc is zero" do
-        let(:wc_result) { "0" }
-
-        it "returns false" do
-          expect(checker_instance.used?("my.key")).to eql false
+      context "not excluding files" do
+        before do
+          expect(checker_instance).to receive(:`).with("git grep my.key you only yolo once | wc -l").and_return(wc_result)
         end
 
-        context "key with recongised plural suffix" do
-          it "chops plural suffix off and returns false" do
-            expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key.zero").and_call_original.ordered
-            expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key").and_call_original.ordered
-            expect(checker_instance.used?("my.key.zero")).to eql false
+        context "wc is zero" do
+          let(:wc_result) { "0" }
+
+          it "returns false" do
+            expect(checker_instance.used?("my.key")).to eql false
+          end
+
+          context "key with recongised plural suffix" do
+            it "chops plural suffix off and returns false" do
+              expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key.zero").and_call_original.ordered
+              expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key").and_call_original.ordered
+              expect(checker_instance.used?("my.key.zero")).to eql false
+            end
+          end
+        end
+
+        context "wc is greater than zero" do
+          let(:wc_result) { "3" }
+
+          it "returns true" do
+            expect(checker_instance.used?("my.key")).to eql true
+          end
+
+          context "key with recongised plural suffix" do
+            it "chops plural suffix off and returns true" do
+              expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key.zero").and_call_original.ordered
+              expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key").and_call_original.ordered
+              expect(checker_instance.used?("my.key.zero")).to eql true
+            end
           end
         end
       end
 
-      context "wc is greater than zero" do
-        let(:wc_result) { "3" }
-
-        it "returns true" do
-          expect(checker_instance.used?("my.key")).to eql true
+      context "excluding files" do
+        let(:checker_instance) do
+          I18n::Hygiene::KeyUsageChecker.new(
+            directories: ["app"],
+            exclude_files: ["ignored.file"]
+          )
         end
 
-        context "key with recongised plural suffix" do
-          it "chops plural suffix off and returns true" do
-            expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key.zero").and_call_original.ordered
-            expect(checker_instance).to receive(:fully_qualified_key_used?).with("my.key").and_call_original.ordered
-            expect(checker_instance.used?("my.key.zero")).to eql true
-          end
+        it "excludes the expected file(s)" do
+          expect(checker_instance).to receive(:`).with("git grep my.key app ':(exclude)*ignored.file' | wc -l").and_return("1")
+
+          checker_instance.used?("my.key")
         end
       end
     end

--- a/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
@@ -68,6 +68,21 @@ describe I18n::Hygiene::KeyUsageChecker do
           checker_instance.used?("my.key")
         end
       end
+
+      context "provided file extensions" do
+        let(:checker_instance) do
+          I18n::Hygiene::KeyUsageChecker.new(
+            directories: ["app"],
+            file_extensions: ["rb", "jsx"]
+          )
+        end
+
+        it "only looks in files that are in the given directories which have the given file extensions" do
+          expect(checker_instance).to receive(:`).with("git grep my.key 'app/*.rb' 'app/*.jsx' | wc -l").and_return("1")
+
+          checker_instance.used?("my.key")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This allows exclusion of files via `config.exclude_files`, which will always include the source location of the file which is calling `RakeTask`.

Also added ability to only scan particular file extensions, by default it will scan "rb", "erb", "coffee", "js", "jsx" (which perhaps we may expand).

This uses the abilities of `git grep` which https://github.com/conversation/i18n-hygiene/pull/28 prepared for.