### PR TITLE
Configure scopes to exclude

### DIFF
--- a/lib/i18n/hygiene/checks/html_entity.rb
+++ b/lib/i18n/hygiene/checks/html_entity.rb
@@ -11,7 +11,7 @@ module I18n
         ENTITY_REGEX = /&\w+;/
 
         def run
-          wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales)
+          wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales, scopes_to_exclude: config.scopes_to_exclude)
 
           keys_with_entities = I18n::Hygiene::KeysWithMatchedValue.new(ENTITY_REGEX, wrapper, reject_keys: reject_keys)
 

--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -15,8 +15,11 @@ module I18n
             exclude_files: config.exclude_files,
             file_extensions: config.file_extensions
           )
-
-          wrapper = I18n::Hygiene::Wrapper.new(keys_to_skip: config.keys_to_skip)
+          
+          wrapper = I18n::Hygiene::Wrapper.new(
+            keys_to_skip: config.keys_to_skip,
+            scopes_to_exclude: config.scopes_to_exclude
+          )
 
           Parallel.each(wrapper.keys_to_check(config.primary_locale), in_threads: config.concurrency) do |key|
             if key_usage_checker.used?(key)

--- a/lib/i18n/hygiene/checks/key_usage.rb
+++ b/lib/i18n/hygiene/checks/key_usage.rb
@@ -17,7 +17,7 @@ module I18n
           )
           
           wrapper = I18n::Hygiene::Wrapper.new(
-            keys_to_skip: config.keys_to_skip,
+            keys_to_exclude: config.keys_to_exclude,
             scopes_to_exclude: config.scopes_to_exclude
           )
 

--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -9,7 +9,7 @@ module I18n
     module Checks
       class MissingInterpolationVariable < Base
         def run
-          wrapper = I18n::Hygiene::Wrapper.new
+          wrapper = I18n::Hygiene::Wrapper.new(scopes_to_exclude: config.scopes_to_exclude)
 
           wrapper.keys_to_check(config.primary_locale).select do |key|
             checker = I18n::Hygiene::VariableChecker.new(key, wrapper, config.primary_locale, config.locales)

--- a/lib/i18n/hygiene/checks/script_tag.rb
+++ b/lib/i18n/hygiene/checks/script_tag.rb
@@ -11,7 +11,7 @@ module I18n
         SCRIPT_TAG_REGEX = /<script.*/
 
         def run
-          wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales)
+          wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales, scopes_to_exclude: config.scopes_to_exclude)
 
           keys_with_script_tags = I18n::Hygiene::KeysWithMatchedValue.new(SCRIPT_TAG_REGEX, wrapper)
 

--- a/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
+++ b/lib/i18n/hygiene/checks/unexpected_return_symbol.rb
@@ -10,7 +10,7 @@ module I18n
         RETURN_SYMBOL_REGEX = /\u23ce/
 
         def run
-          wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales)
+          wrapper = I18n::Hygiene::Wrapper.new(locales: all_locales, scopes_to_exclude: config.scopes_to_exclude)
           keys_with_return_symbols = I18n::Hygiene::KeysWithMatchedValue.new(RETURN_SYMBOL_REGEX, wrapper)
 
           keys_with_return_symbols.each do |locale, key|

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -8,7 +8,7 @@ module I18n
       attr_writer :file_extensions
       attr_writer :primary_locale
       attr_writer :locales
-      attr_writer :keys_to_skip
+      attr_writer :keys_to_exclude
       attr_writer :concurrency
       attr_writer :scopes_to_exclude
 
@@ -36,8 +36,8 @@ module I18n
         [primary_locale] + locales
       end
 
-      def keys_to_skip
-        @keys_to_skip ||= []
+      def keys_to_exclude
+        @keys_to_exclude ||= []
       end
 
       def concurrency

--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -10,6 +10,7 @@ module I18n
       attr_writer :locales
       attr_writer :keys_to_skip
       attr_writer :concurrency
+      attr_writer :scopes_to_exclude
 
       def exclude_files
         @exclude_files ||= []
@@ -41,6 +42,10 @@ module I18n
 
       def concurrency
         @concurrency || Parallel.processor_count
+      end
+
+      def scopes_to_exclude
+        @scopes_to_exclude ||= []
       end
     end
   end

--- a/lib/i18n/hygiene/keys_with_matched_value.rb
+++ b/lib/i18n/hygiene/keys_with_matched_value.rb
@@ -6,7 +6,7 @@ module I18n
 
       def initialize(regex, i18n_wrapper = nil, reject_keys: nil)
         @regex = regex
-        @i18n = i18n_wrapper || I18n::Hygiene::Wrapper.new(keys_to_skip: [])
+        @i18n = i18n_wrapper || I18n::Hygiene::Wrapper.new(keys_to_exclude: [])
         @reject_keys = reject_keys
       end
 

--- a/lib/i18n/hygiene/locale_translations.rb
+++ b/lib/i18n/hygiene/locale_translations.rb
@@ -10,9 +10,10 @@ module I18n
       # These are i18n keys provided by Rails. We cannot exclude them at the :helpers
       # scope level because we do have some TC i18n keys scoped within :helpers.
 
-      def initialize(translations:, keys_to_skip:)
+      def initialize(translations:, keys_to_skip:, scopes_to_exclude:)
         @translations = translations
         @keys_to_skip = keys_to_skip || []
+        @scopes_to_exclude = scopes_to_exclude || []
       end
 
       def keys_to_check
@@ -24,35 +25,15 @@ module I18n
       private
 
       def translations_to_check
-        @translations.reject { |k, _v| non_tc_scopes.include? k }
-      end
-
-      def non_tc_scopes
-        scopes_from_rails + scopes_from_devise + scopes_from_kaminari + scopes_from_i18n_country_select + scopes_from_faker
-      end
-
-      def scopes_from_rails
-        [ :activerecord, :date, :datetime, :errors, :number, :support, :time ]
-      end
-
-      def scopes_from_devise
-        [ :devise ]
-      end
-
-      def scopes_from_kaminari
-        [ :views ]
-      end
-
-      def scopes_from_i18n_country_select
-        [ :countries ]
-      end
-
-      def scopes_from_faker
-        [ :faker ]
+        @translations.reject { |k, _v| scopes_to_exclude.include? k }
       end
 
       def keys_to_skip
         @keys_to_skip
+      end
+
+      def scopes_to_exclude
+        @scopes_to_exclude
       end
 
       def fully_qualified_keys(hash)

--- a/lib/i18n/hygiene/locale_translations.rb
+++ b/lib/i18n/hygiene/locale_translations.rb
@@ -10,15 +10,15 @@ module I18n
       # These are i18n keys provided by Rails. We cannot exclude them at the :helpers
       # scope level because we do have some TC i18n keys scoped within :helpers.
 
-      def initialize(translations:, keys_to_skip:, scopes_to_exclude:)
+      def initialize(translations:, keys_to_exclude:, scopes_to_exclude:)
         @translations = translations
-        @keys_to_skip = keys_to_skip || []
+        @keys_to_exclude = keys_to_exclude || []
         @scopes_to_exclude = scopes_to_exclude || []
       end
 
       def keys_to_check
         fully_qualified_keys(translations_to_check).reject { |key|
-          keys_to_skip.include?(key) || EXAMPLE_KEY == key
+          keys_to_exclude.include?(key) || EXAMPLE_KEY == key
         }.sort
       end
 
@@ -28,8 +28,8 @@ module I18n
         @translations.reject { |k, _v| scopes_to_exclude.include? k }
       end
 
-      def keys_to_skip
-        @keys_to_skip
+      def keys_to_exclude
+        @keys_to_exclude
       end
 
       def scopes_to_exclude

--- a/lib/i18n/hygiene/wrapper.rb
+++ b/lib/i18n/hygiene/wrapper.rb
@@ -8,16 +8,16 @@ module I18n
     # queryable.
     class Wrapper
 
-      def initialize(keys_to_skip: [], scopes_to_exclude: [], locales: ::I18n.available_locales)
+      def initialize(keys_to_exclude: [], scopes_to_exclude: [], locales: ::I18n.available_locales)
         @locales = locales
-        @keys_to_skip = keys_to_skip
+        @keys_to_exclude = keys_to_exclude
         @scopes_to_exclude = scopes_to_exclude
       end
 
       def keys_to_check(locale)
         I18n::Hygiene::LocaleTranslations.new(
           translations: translations[locale],
-          keys_to_skip: keys_to_skip,
+          keys_to_exclude: keys_to_exclude,
           scopes_to_exclude: scopes_to_exclude
         ).keys_to_check
       end
@@ -49,8 +49,8 @@ module I18n
         ::I18n.backend.send(:init_translations)
       end
 
-      def keys_to_skip
-        @keys_to_skip
+      def keys_to_exclude
+        @keys_to_exclude
       end
 
       def scopes_to_exclude

--- a/lib/i18n/hygiene/wrapper.rb
+++ b/lib/i18n/hygiene/wrapper.rb
@@ -8,13 +8,18 @@ module I18n
     # queryable.
     class Wrapper
 
-      def initialize(keys_to_skip: [], locales: ::I18n.available_locales)
+      def initialize(keys_to_skip: [], scopes_to_exclude: [], locales: ::I18n.available_locales)
         @locales = locales
         @keys_to_skip = keys_to_skip
+        @scopes_to_exclude = scopes_to_exclude
       end
 
       def keys_to_check(locale)
-        I18n::Hygiene::LocaleTranslations.new(translations: translations[locale], keys_to_skip: keys_to_skip).keys_to_check
+        I18n::Hygiene::LocaleTranslations.new(
+          translations: translations[locale],
+          keys_to_skip: keys_to_skip,
+          scopes_to_exclude: scopes_to_exclude
+        ).keys_to_check
       end
 
       def locales
@@ -46,6 +51,10 @@ module I18n
 
       def keys_to_skip
         @keys_to_skip
+      end
+
+      def scopes_to_exclude
+        @scopes_to_exclude
       end
 
     end

--- a/spec/fixtures/valid.Rakefile
+++ b/spec/fixtures/valid.Rakefile
@@ -9,7 +9,7 @@ I18n::Hygiene::RakeTask.new(:default) do |config|
   config.directories = ["spec/fixtures/project/app", "spec/fixtures/project/lib"]
   config.primary_locale = :en_valid
   config.locales = [:fr_valid]
-  config.keys_to_skip = "translation.dynamic"
+  config.keys_to_exclude = "translation.dynamic"
   config.file_extensions = ["rb", "jsx"]
   config.concurrency = 1
 end

--- a/spec/lib/i18n/hygiene/config_spec.rb
+++ b/spec/lib/i18n/hygiene/config_spec.rb
@@ -37,4 +37,11 @@ RSpec.describe I18n::Hygiene::Config do
       expect(config.directories).to eq ["app", "lib"]
     end
   end
+
+  describe "#scopes_to_exclude=" do
+    it "sets scopes to exclude" do
+      config.scopes_to_exclude = [ :activerecord, :date, :datetime, :errors, :number, :support, :time ]
+      expect(config.scopes_to_exclude).to eq [ :activerecord, :date, :datetime, :errors, :number, :support, :time ]
+    end
+  end
 end

--- a/spec/lib/i18n/hygiene/locale_translations_spec.rb
+++ b/spec/lib/i18n/hygiene/locale_translations_spec.rb
@@ -5,7 +5,7 @@ describe I18n::Hygiene::LocaleTranslations do
   let(:translations) {
     I18n::Hygiene::LocaleTranslations.new(
       translations: all_translations,
-      keys_to_skip: keys_to_skip,
+      keys_to_exclude: keys_to_exclude,
       scopes_to_exclude: scopes_to_exclude
     )
   }
@@ -19,7 +19,7 @@ describe I18n::Hygiene::LocaleTranslations do
       foo: { bar: "baz" },
     }
   end
-  let(:keys_to_skip) {
+  let(:keys_to_exclude) {
     [
       "helpers.select.prompt",
       "helpers.submit.create",

--- a/spec/lib/i18n/hygiene/locale_translations_spec.rb
+++ b/spec/lib/i18n/hygiene/locale_translations_spec.rb
@@ -2,7 +2,13 @@ require 'i18n'
 require 'i18n/hygiene'
 
 describe I18n::Hygiene::LocaleTranslations do
-  let(:translations) { I18n::Hygiene::LocaleTranslations.new(translations: all_translations, keys_to_skip: keys_to_skip) }
+  let(:translations) {
+    I18n::Hygiene::LocaleTranslations.new(
+      translations: all_translations,
+      keys_to_skip: keys_to_skip,
+      scopes_to_exclude: scopes_to_exclude
+    )
+  }
   let(:all_translations) do
     {
       activerecord: "abc",
@@ -19,6 +25,11 @@ describe I18n::Hygiene::LocaleTranslations do
       "helpers.submit.create",
       "helpers.submit.submit",
       "helpers.submit.update"
+    ]
+  }
+  let(:scopes_to_exclude) {
+    [
+      :activerecord, :devise, :views
     ]
   }
 

--- a/spec/lib/i18n/hygiene/wrapper_spec.rb
+++ b/spec/lib/i18n/hygiene/wrapper_spec.rb
@@ -2,7 +2,7 @@ require 'i18n'
 require 'i18n/hygiene'
 
 describe I18n::Hygiene::Wrapper do
-  let(:wrapper) { I18n::Hygiene::Wrapper.new(keys_to_skip: []) }
+  let(:wrapper) { I18n::Hygiene::Wrapper.new(keys_to_exclude: []) }
 
   before do
     [:en, :fr, :es].each do |locale|


### PR DESCRIPTION
Up until now we have assumed that Rails and some other gems e.g. Devise are being used.

This PR introduces the configuration option to exclude keys that are scopes with a common prefix e.g. `:activerecord`.

In `I18n::Hygiene::LocaleTranslations` the `non_tc_scopes` and `scopes_from_*` methods which are currently used to exclude translation keys from those that are checked will no longer be hard-coded. Rather, client applications such as TC will need to be configured to exclude these scopes.