### PR TITLE
Default primary locale uses I18n.default_locale

### DIFF
--- a/lib/i18n/hygiene/config.rb
+++ b/lib/i18n/hygiene/config.rb
@@ -25,7 +25,7 @@ module I18n
       end
 
       def primary_locale
-        @primary_locale ||= :en
+        @primary_locale ||= ::I18n.default_locale
       end
 
       def locales


### PR DESCRIPTION
While Eleanor and I were preparing the 1.0.0 branch, we discovered that the default primary locale was still hard coded to `:en`