### PR TITLE
stop skipping common.greeting key

### DIFF
--- a/lib/i18n/hygiene/locale_translations.rb
+++ b/lib/i18n/hygiene/locale_translations.rb
@@ -4,9 +4,6 @@ module I18n
     # aren't in our control. Can return the i18n keys that **are** in our control,
     # and therefore are interesting for a variety of reasons.
     class LocaleTranslations
-      # This is a default example key in the locale files that is not actually used.
-      EXAMPLE_KEY = "common.greeting"
-
       # These are i18n keys provided by Rails. We cannot exclude them at the :helpers
       # scope level because we do have some TC i18n keys scoped within :helpers.
 
@@ -18,7 +15,7 @@ module I18n
 
       def keys_to_check
         fully_qualified_keys(translations_to_check).reject { |key|
-          exclude_keys.include?(key) || EXAMPLE_KEY == key
+          exclude_keys.include?(key)
         }.sort
       end
 

--- a/spec/lib/i18n/hygiene/locale_translations_spec.rb
+++ b/spec/lib/i18n/hygiene/locale_translations_spec.rb
@@ -14,7 +14,6 @@ describe I18n::Hygiene::LocaleTranslations do
       activerecord: "abc",
       devise: "abc",
       views: "abc",
-      common: { greeting: "Hello!" },
       helpers: { select: { prompt: "?" } },
       foo: { bar: "baz" },
     }


### PR DESCRIPTION
This key is used in our internal apps to test that locales are configured and available, but it's not a standard rails key.

To confirm that, I created a new rails 5.0.3 app and the default en locale has a single key: `hello`.

I think it's best for this gem to allow those default keys to be tested, and if the user wants to skip them they can add the key to `exclude_keys`.