### PR TITLE
stop ignoring i18n.* keys in KeyUsageChecker

### DIFF
--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -12,7 +12,7 @@ module I18n
       end
 
       def used?(key)
-        i18n_config_key?(key) || fully_qualified_key_used?(key)
+        fully_qualified_key_used?(key)
       end
 
       private
@@ -45,10 +45,6 @@ module I18n
         @exclude_files.map { |file|
           "':(exclude)*#{file}'"
         }.join(" ")
-      end
-
-      def i18n_config_key?(key)
-        key.start_with?("i18n.")
       end
 
       def pluralized_key_used?(key)

--- a/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
@@ -9,12 +9,6 @@ describe I18n::Hygiene::KeyUsageChecker do
   end
 
   describe '#used?' do
-    context "key is prefixed with i18n" do
-      it "returns true" do
-        expect(checker_instance.used?("i18n.my.key")).to eql true
-      end
-    end
-
     context "shelling out" do
       context "not excluding files" do
         before do


### PR DESCRIPTION
The check that confirms each key is used was hard coded to ignore any keys that start with "i18n.".

This namespace is used by the i18n to lookup config for features like pluralisation and transliteration. It's like that users will want these keys ignored by the key usage check, but it's also possible there may be other keys with the same prefix that they want to check.

I think it would be best for the check to assume all keys should be checked, and the user can use `exclude_keys` or `exclude_scopes` to explicitly choose the keys they want ignored.