### PR TITLE
TC-159 Fix greedy regex

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,12 @@
 ### Development
 [Full Changelog](https://github.com/conversation/i18n-hygiene/compare/v1.0.0...master)
 
+### [1.0.2] - 2018-10-25
+
+Bug fixes:
+
+* Prevent greedy variable checker from raising spurious errors
+
 ### [1.0.1] - 2017-08-07
 
 Enhancements:

--- a/i18n-hygiene.gemspec
+++ b/i18n-hygiene.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'i18n-hygiene'
-  s.version = '1.0.1'
+  s.version = '1.0.2'
   s.license = 'MIT'
   s.summary = "A linter for translation data in ruby applications"
   s.description = "Provides a configurable rake task that checks locale data for likely issues. Intended to be used in build pipelines to detect problems before they reach production"

--- a/lib/i18n/hygiene/variable_checker.rb
+++ b/lib/i18n/hygiene/variable_checker.rb
@@ -37,7 +37,7 @@ module I18n
       end
 
       def rails_variables(string)
-        string.scan(/%{\S+}/).map { |var_string| var_string.gsub(/[%{}]/, '').to_sym }
+        string.scan(/%{\S+?}/).map { |var_string| var_string.gsub(/[%{}]/, '').to_sym }.uniq
       end
 
       def js_variables(string)

--- a/spec/lib/i18n/hygiene/variable_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/variable_checker_spec.rb
@@ -5,13 +5,13 @@ describe I18n::Hygiene::VariableChecker do
   let(:i18n_wrapper) { instance_double("TC::I18nWrapper") }
   let(:checker) { I18n::Hygiene::VariableChecker.new("test_key", i18n_wrapper, :en, [:fr]) }
   let(:checker_markdown) { I18n::Hygiene::VariableChecker.new("test_key_markdown", i18n_wrapper, :en, [:fr]) }
-  let(:base_value) { "A sentence with a variable %{variable_key}"  }
-  let(:base_js_value) { "A sentence with a variable __variable_key__"  }
-  let(:matching_value) { "Translation with correct variable %{variable_key}"  }
-  let(:matching_js_value) { "Translation with correct variable __variable_key__"  }
+  let(:base_value) { "A sentence with a variable %{variable_key}" }
+  let(:base_js_value) { "A sentence with a variable __variable_key__" }
+  let(:matching_value) { "Translation with correct variable %{variable_key}" }
+  let(:matching_js_value) { "Translation with correct variable __variable_key__" }
   let(:mismatch) { "Translation with wrong variable %{bad_key}" }
   let(:mismatch_js) { "Translation with wrong variable __bad_key__" }
-  let(:mismatch_info) { "test_key for locale fr is missing interpolation variable(s): variable_key"  }
+  let(:mismatch_info) { "test_key for locale fr is missing interpolation variable(s): variable_key" }
   let(:markdown_italic_en) { "Within Markdown __italics__ ignore" }
   let(:markdown_italic_fr) { "Within Markdown __italiques__ ignore" }
 

--- a/spec/lib/i18n/hygiene/variable_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/variable_checker_spec.rb
@@ -5,7 +5,7 @@ describe I18n::Hygiene::VariableChecker do
   let(:i18n_wrapper) { instance_double("TC::I18nWrapper") }
   let(:checker) { I18n::Hygiene::VariableChecker.new("test_key", i18n_wrapper, :en, [:fr]) }
   let(:checker_markdown) { I18n::Hygiene::VariableChecker.new("test_key_markdown", i18n_wrapper, :en, [:fr]) }
-  let(:base_value) { "A sentence with a variable %{variable_key}" }
+  let(:base_value) { "A sentence with a variable [%{variable_key}](%{variable_key})" }
   let(:base_js_value) { "A sentence with a variable __variable_key__" }
   let(:matching_value) { "Translation with correct variable %{variable_key}" }
   let(:matching_js_value) { "Translation with correct variable __variable_key__" }


### PR DESCRIPTION
The regular expression matching the variables in the source was greedy
and producing spurious mismatching errors.

In particular if the source had the following:

```
here is some text [%{hello}](%{world})
```

would require the translation to have the variable `:hello](world` instead of two variables `:hello` and `:world`.

By making the regex lazy it won't match on the final `}`