### PR TITLE
 Update i18n dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Gemfile.lock
+.bundle
+vendor/bundle

--- a/i18n-hygiene.gemspec
+++ b/i18n-hygiene.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md"]
   s.rdoc_options << "--title" << "i18n-hygiene documentation" << "--main" << "README.md"
 
-  s.add_dependency 'i18n', ['~> 0.6', '>= 0.6.9']
+  s.add_dependency 'i18n', '>= 0.6.9', '< 2'
   s.add_dependency 'parallel', '~> 1.3'
   s.add_dependency 'rainbow', '>= 1.99.1', '< 3.0'
   s.add_dependency 'rake', '>= 0.8.7'

--- a/i18n-hygiene.gemspec
+++ b/i18n-hygiene.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.email = "dev@theconversation.edu.au"
   s.files = `git ls-files -- lib/*`.split("\n")
   s.homepage = 'https://github.com/conversation/i18n-hygiene'
-  s.has_rdoc = true
   s.extra_rdoc_files = ["README.md"]
   s.rdoc_options << "--title" << "i18n-hygiene documentation" << "--main" << "README.md"
 


### PR DESCRIPTION
This restriction limits consumers to reasonably old versions of i18n, which causes conflicts with other gems, e.g.

```
rails (= 5.2.3) was resolved to 5.2.3, which depends on
  activesupport (= 5.2.3) was resolved to 5.2.3, which depends on
    i18n (< 2, >= 0.7)

faker (~> 2.11) was resolved to 2.11.0, which depends on
  i18n (< 2, >= 1.6)

i18n-hygiene was resolved to 1.0.2, which depends on
  i18n (>= 0.6.9, ~> 0.6)