### PR TITLE
Ignore interpolation check for excluded keys in i18n hygiene

### DIFF
--- a/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
+++ b/lib/i18n/hygiene/checks/missing_interpolation_variable.rb
@@ -11,7 +11,10 @@ module I18n
       # Looks for translations which are missing interpolation variables.
       class MissingInterpolationVariable < Base
         def run
-          wrapper = I18n::Hygiene::Wrapper.new(exclude_scopes: config.exclude_scopes)
+          wrapper = I18n::Hygiene::Wrapper.new(
+            exclude_keys: config.exclude_keys,
+            exclude_scopes: config.exclude_scopes
+          )
 
           wrapper.keys_to_check(config.primary_locale).select do |key|
             checker = I18n::Hygiene::VariableChecker.new(key, wrapper, config.primary_locale, config.locales)

--- a/spec/fixtures/locales/en_valid.yml
+++ b/spec/fixtures/locales/en_valid.yml
@@ -8,3 +8,4 @@ en_valid:
       other: "bars"
     full_key: "baz"
     interpolation: "%{qux}"
+    ignored_key: "rofl %{quz}"

--- a/spec/fixtures/locales/fr_valid.yml
+++ b/spec/fixtures/locales/fr_valid.yml
@@ -8,3 +8,4 @@ fr_valid:
       other: "bars"
     full_key: "baz"
     interpolation: "%{qux}"
+    ignored_key: "rofl"

--- a/spec/fixtures/valid.Rakefile
+++ b/spec/fixtures/valid.Rakefile
@@ -9,7 +9,7 @@ I18n::Hygiene::RakeTask.new(:default) do |config|
   config.directories = ["spec/fixtures/project/app", "spec/fixtures/project/lib"]
   config.primary_locale = :en_valid
   config.locales = [:fr_valid]
-  config.exclude_keys = "translation.dynamic"
+  config.exclude_keys = ["translation.dynamic", "translation.ignored_key"]
   config.file_extensions = ["rb", "jsx"]
   config.concurrency = 1
 end


### PR DESCRIPTION
This PR makes sure we don't check missing interpolation keys if they are part of the exluded keys list, so that we can add interpolation keys in TC without being required to use them in _all_ locale files. 

This is particularly useful if we want to gradually roll out changes to our translations.

For example, see [this PR](https://github.com/conversation/tc/pull/11802) where we added a bunch of interpolation keys for English locales only.

## How to test

Revert the change to the `MissingInterpolationVariable` class and check that the tests fail.