### PR TITLE
Replace `git grep` with `grep`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ### Development
 [Full Changelog](https://github.com/conversation/i18n-hygiene/compare/v1.0.0...master)
 
+### [1.3.0] - 2022-02-23
+
+* Drop `git` dependency. Use system's `grep` instead `git grep`
+* Fixes a bug where the `exclude_files` wouldn't work
+
 ### [1.2.0] - 2021-11-26
 
 * Ignore interpolation check for excluded keys

--- a/i18n-hygiene.gemspec
+++ b/i18n-hygiene.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'i18n-hygiene'
-  s.version = '1.2.0'
+  s.version = '1.3.0'
   s.license = 'MIT'
   s.summary = "A linter for translation data in ruby applications"
   s.description = "Provides a configurable rake task that checks locale data for likely issues. Intended to be used in build pipelines to detect problems before they reach production"

--- a/lib/i18n/hygiene/key_usage_checker.rb
+++ b/lib/i18n/hygiene/key_usage_checker.rb
@@ -7,6 +7,8 @@ module I18n
         @directories = directories
         @exclude_files = exclude_files
         @file_extensions = file_extensions
+
+        raise "Must have grep installed!" unless system("which grep > /dev/null")
       end
 
       def used?(key)

--- a/spec/i18n_hygiene_spec.rb
+++ b/spec/i18n_hygiene_spec.rb
@@ -27,10 +27,7 @@ RSpec.describe "i18n-hygiene" do
 
           i18n-hygiene/Unused translation:
             translation.dynamic
-
-          i18n-hygiene/Unused translation:
-            translation.ignored
-          ...
+          ....
           i18n-hygiene/Unused translation:
             translation.script
 

--- a/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
+++ b/spec/lib/i18n/hygiene/key_usage_checker_spec.rb
@@ -12,7 +12,7 @@ describe I18n::Hygiene::KeyUsageChecker do
     context "shelling out" do
       context "not excluding files" do
         before do
-          expect(checker_instance).to receive(:`).with("git grep my.key you only yolo once | wc -l").and_return(wc_result)
+          expect(checker_instance).to receive(:`).with("grep --recursive my.key you only yolo once | wc -l").and_return(wc_result)
         end
 
         context "wc is zero" do
@@ -57,7 +57,7 @@ describe I18n::Hygiene::KeyUsageChecker do
         end
 
         it "excludes the expected file(s)" do
-          expect(checker_instance).to receive(:`).with("git grep my.key app ':(exclude)*ignored.file' | wc -l").and_return("1")
+          expect(checker_instance).to receive(:`).with("grep --recursive my.key --exclude=\"ignored.file\" app | wc -l").and_return("1")
 
           checker_instance.used?("my.key")
         end
@@ -72,7 +72,7 @@ describe I18n::Hygiene::KeyUsageChecker do
         end
 
         it "only looks in files that are in the given directories which have the given file extensions" do
-          expect(checker_instance).to receive(:`).with("git grep my.key 'app/*.rb' 'app/*.jsx' | wc -l").and_return("1")
+          expect(checker_instance).to receive(:`).with("grep --recursive my.key --include=\"*.rb\" --include=\"*.jsx\" app | wc -l").and_return("1")
 
           checker_instance.used?("my.key")
         end


### PR DESCRIPTION
Instead relying that hosts running this gem's hygiene rake task will have `git` installed, let's use their builtin `grep` command.

Using `grep` also avoids issues when major history rewrites or file renaming occurs on a `git` project. We are not relying on `git` history or file structure anymore.

This PR maintains its backwards compatible with previous `i18n-hygiene` arguments.

**How to test it?**

You can use this branch to test out if it works:

```ruby
gem "i18n-hygiene", git: "https://github.com/conversation/i18n-hygiene.git", branch: "9316-replace-git-grep-with-plain-grep-on-i18n-hygiene-gem"
```